### PR TITLE
Add a method to monkey_patch pandas.

### DIFF
--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -23,3 +23,12 @@ def nbinstall(overwrite=False):
         symlink=False,
         verbose=0,
     )
+
+
+def monkey_patch(pandas, remote_js=False):
+    "Make qgrid the default display method for DataFrames."
+
+    def _ipython_display_(self):
+        return show_grid(self, remote_js=remote_js)._ipython_display_()
+
+    pandas.DataFrame._ipython_display_ = _ipython_display_


### PR DESCRIPTION
Make a way for qgrid to be the default display method for DataFrames, via a new `monkey_patch()` method.

``` python
import pandas as pd
import qgrid
qgrid.monkey_patch(pd, remote_js=True)
```

After that, every time a DataFrame is displayed it will now have a `_ipython_display_()` method which renders it as a SlickGrid.
