### PR TITLE
DEV: Added support for IPython 2.x in nbinstall(). Fixes #16.

### DIFF
--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -18,21 +18,10 @@ def nbinstall(user=True, overwrite=False):
         'qgridjs',
     )
 
-    if version_info >= (3, 0, 0, ''):
-        install_nbextension(
-            qgridjs_path,
-            overwrite=overwrite,
-            user=user,
-            symlink=False,
-            verbose=0,
-        )
-    elif version_info >= (2, 0, 0, ''):
-        # Leave out the user argument with IPython 2.x series
-        install_nbextension(
-            qgridjs_path,
-            overwrite=overwrite,
-            symlink=False,
-            verbose=0,
-        )
-    else:
-        raise NotImplementedError("Only supported for IPython>=2.0.")
+    install_nbextension(
+        qgridjs_path,
+        overwrite=overwrite,
+        symlink=False,
+        verbose=0,
+        **({'user': user} if version_info>=(3, 0, 0, '') else {})
+    )

--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -11,16 +11,28 @@ def nbinstall(user=True, overwrite=False):
     # Lazy imports so we don't pollute the namespace.
     import os
     from IPython.html.nbextensions import install_nbextension
+    from IPython import version_info
 
     qgridjs_path = os.path.join(
         os.path.dirname(__file__),
         'qgridjs',
     )
 
-    install_nbextension(
-        qgridjs_path,
-        overwrite=overwrite,
-        user=user,
-        symlink=False,
-        verbose=0,
-    )
+    if version_info >= (3, 0, 0, ''):
+        install_nbextension(
+            qgridjs_path,
+            overwrite=overwrite,
+            user=user,
+            symlink=False,
+            verbose=0,
+        )
+    elif version_info >= (2, 0, 0, ''):
+        # Leave out the user argument with IPython 2.x series
+        install_nbextension(
+            qgridjs_path,
+            overwrite=overwrite,
+            symlink=False,
+            verbose=0,
+        )
+    else:
+        raise NotImplementedError("Only supported for IPython>=2.0.")


### PR DESCRIPTION
I use IPython 2.x Notebooks in wide deployment and would like to use qgrid. I won't be able to upgrade these to Jupyter/IPython 3.x anytime soon so it would be great if we could keep IPython 2.x support.

This small change in nbinstall() seems to be all that is required and with this qgrid works well for me in IPython 2.4.1.