### PR TITLE
 DEV: Added support for custom Notebook server base_url(s). Fixes #21.

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -6,6 +6,17 @@ import json
 
 from IPython.display import display_html, display_javascript
 
+from IPython import get_ipython
+ipython = get_ipython()
+if ipython and ('NotebookApp' in ipython.config) and \
+        ('base_url' in ipython.config['NotebookApp']):
+    NOTEBOOK_BASE_URL = ipython.config['NotebookApp']['base_url']
+else:
+    NOTEBOOK_BASE_URL = ''
+LOCAL_BASE_URL = NOTEBOOK_BASE_URL + "/nbextensions/qgridjs"
+CDN_BASE_URL = "https://cdn.rawgit.com/quantopian/qgrid/"\
+    + "ddf33c0efb813cd574f3838f6cf1fd584b733621/qgrid/qgridjs/"
+
 
 def template_contents(filename):
     template_filepath = os.path.join(
@@ -61,10 +72,9 @@ class SlickGrid(object):
             )
 
             if self.remote_js:
-                cdn_base_url = \
-                    "https://cdn.rawgit.com/quantopian/qgrid/ddf33c0efb813cd574f3838f6cf1fd584b733621/qgrid/qgridjs/"
+                cdn_base_url = CDN_BASE_URL
             else:
-                cdn_base_url = "/nbextensions/qgridjs"
+                cdn_base_url = LOCAL_BASE_URL
 
             raw_html = SLICK_GRID_CSS.format(
                 div_id=self.div_id,


### PR DESCRIPTION
Without this change show_grid() will not work when you have a custom prefix such as '/MYAPP' as part of your URL.

This change allows it to work on my installation which has a custom prefix. I hope to have preserved the functionality on installations where a custom prefix isn't present but I don't have an instance like that to test it myself.

This fixes issue #21.