### PR TITLE
Allow overriding of SlickGrid options

### DIFF
--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,8 +1,4 @@
-from .grid import SlickGrid
-
-
-def show_grid(data_frame, remote_js=False):
-    return SlickGrid(data_frame, remote_js)
+from .grid import show_grid, SlickGrid      # noqa
 
 
 def nbinstall(user=True, overwrite=False):

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -21,9 +21,13 @@ SLICK_GRID_CSS = template_contents('slickgrid.css.template')
 SLICK_GRID_JS = template_contents('slickgrid.js.template')
 
 
+def show_grid(data_frame, *args, **kwargs):
+    return SlickGrid(data_frame, *args, **kwargs)
+
+
 class SlickGrid(object):
 
-    def __init__(self, data_frame, remote_js=False):
+    def __init__(self, data_frame, remote_js=False, precision=None):
         self.data_frame = data_frame
         self.remote_js = remote_js
         self.div_id = str(uuid.uuid4())
@@ -49,7 +53,12 @@ class SlickGrid(object):
                     break
             self.column_types.append(column_type)
 
-        self.precision = pd.get_option('display.precision') - 1
+        if isinstance(precision, int) and precision>=0:
+            self.precision = precision
+        elif precision is None:
+            self.precision = pd.get_option('display.precision') - 1
+        else:
+            raise TypeError('precision')
 
     def _ipython_display_(self):
         try:

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -20,6 +20,15 @@ def template_contents(filename):
 SLICK_GRID_CSS = template_contents('slickgrid.css.template')
 SLICK_GRID_JS = template_contents('slickgrid.js.template')
 
+SLICK_GRID_DEFAULT_OPTIONS = {
+    'enableCellNavigation': True,
+    'fullWidthRows': True,
+    'syncColumnCellResize': True,
+    'forceFitColumns': True,
+    'rowHeight': 28,
+    'enableColumnReorder': False,
+    'enableTextSelectionOnCells': True, }
+
 
 def show_grid(data_frame, *args, **kwargs):
     return SlickGrid(data_frame, *args, **kwargs)
@@ -27,7 +36,8 @@ def show_grid(data_frame, *args, **kwargs):
 
 class SlickGrid(object):
 
-    def __init__(self, data_frame, remote_js=False, precision=None):
+    def __init__(self, data_frame, remote_js=False, precision=None,
+                 options={}):
         self.data_frame = data_frame
         self.remote_js = remote_js
         self.div_id = str(uuid.uuid4())
@@ -60,6 +70,11 @@ class SlickGrid(object):
         else:
             raise TypeError('precision')
 
+        if not isinstance(options, dict):
+            raise TypeError('options')
+        self.options = SLICK_GRID_DEFAULT_OPTIONS.copy()
+        self.options.update(options)
+
     def _ipython_display_(self):
         try:
             column_types_json = json.dumps(self.column_types)
@@ -68,6 +83,7 @@ class SlickGrid(object):
                 date_format='iso',
                 double_precision=self.precision,
             )
+            options_json = json.dumps(self.options)
 
             if self.remote_js:
                 cdn_base_url = \
@@ -84,6 +100,7 @@ class SlickGrid(object):
                 div_id=self.div_id,
                 data_frame_json=data_frame_json,
                 column_types_json=column_types_json,
+                options_json=options_json,
             )
 
             display_html(raw_html, raw=True)

--- a/qgrid/qgridjs/qgrid.js
+++ b/qgrid/qgridjs/qgrid.js
@@ -81,7 +81,7 @@ define([
     }, this);
   }
 
-  QGrid.prototype.initialize_slick_grid = function () {
+  QGrid.prototype.initialize_slick_grid = function (options) {
     this.data_view = new Slick.Data.DataView({
       inlineFilters: false,
       enableTextSelectionOnCells: true
@@ -93,16 +93,6 @@ define([
     this.data_view.setItems(this.row_data);
     this.data_view.setFilter($.proxy(this.include_row, this));
     this.data_view.endUpdate();
-
-    var options = {
-      enableCellNavigation: true,
-      fullWidthRows: true,
-      syncColumnCellResize: true,
-      forceFitColumns: true,
-      rowHeight: 28,
-      enableColumnReorder: false,
-      enableTextSelectionOnCells: true
-    };
 
     var max_height = options.rowHeight * 15;
     var grid_height = max_height;

--- a/qgrid/templates/slickgrid.js.template
+++ b/qgrid/templates/slickgrid.js.template
@@ -49,7 +49,7 @@ function($){{
     ], function(){{
         require(["data_grid"], function(dgrid){{
             var grid = new dgrid.QGrid('#{div_id}', {data_frame_json}, {column_types_json});
-            grid.initialize_slick_grid();
+            grid.initialize_slick_grid({options_json});
         }});
     }});
 }});


### PR DESCRIPTION
I wanted a way to override the forceFitColumns parameter and this PR works for me.

Example usage:

    display(qgrid.SlickGrid(grid_data, options={'forceFitColumns':False}))