### PR TITLE
Adds support for Globally-configurable options.

### DIFF
--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,4 +1,8 @@
-from .grid import show_grid, SlickGrid      # noqa
+from .grid import (
+    set_defaults,
+    set_js_option,
+    show_grid,
+)
 
 
 def nbinstall(user=True, overwrite=False):
@@ -20,3 +24,6 @@ def nbinstall(user=True, overwrite=False):
         symlink=False,
         verbose=0,
     )
+
+
+__all__ = ['show_grid', 'set_defaults', 'set_js_option']

--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,8 +1,4 @@
-from .grid import SlickGrid
-
-
-def show_grid(data_frame, remote_js=False):
-    return SlickGrid(data_frame, remote_js)
+from .grid import show_grid, SlickGrid      # noqa
 
 
 def nbinstall(user=True, overwrite=False):

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -4,7 +4,6 @@ import os
 import uuid
 import json
 from numbers import Integral
-from types import DictType
 
 from IPython.display import display_html, display_javascript
 
@@ -26,7 +25,7 @@ SLICK_GRID_JS = template_contents('slickgrid.js.template')
 class _DefaultSettings(object):
 
     def __init__(self):
-        self._js_options = {
+        self._grid_options = {
             'enableCellNavigation': True,
             'fullWidthRows': True,
             'syncColumnCellResize': True,
@@ -49,9 +48,9 @@ class _DefaultSettings(object):
         optvalue : object
             The new value
         """
-        self._js_options[optname] = optvalue
+        self._grid_options[optname] = optvalue
 
-    def set_defaults(self, remote_js=None, precision=None, js_options=None):
+    def set_defaults(self, remote_js=None, precision=None, grid_options=None):
         """
         Set a default value to be passed to Python SlickGrid instances.
 
@@ -61,12 +60,12 @@ class _DefaultSettings(object):
             self._remote_js = remote_js
         if precision is not None:
             self._precision = precision
-        if js_options is not None:
-            self._js_options = js_options
+        if grid_options is not None:
+            self._grid_options = grid_options
 
     @property
-    def js_options(self):
-        return self._js_options
+    def grid_options(self):
+        return self._grid_options
 
     @property
     def remote_js(self):
@@ -81,7 +80,7 @@ set_defaults = defaults.set_defaults
 set_js_option = defaults.set_js_option
 
 
-def show_grid(data_frame, remote_js=None, precision=None, js_options=None):
+def show_grid(data_frame, remote_js=None, precision=None, grid_options=None):
     """
     Main entry point for rendering DataFrames as SlickGrids.
 
@@ -97,7 +96,7 @@ def show_grid(data_frame, remote_js=None, precision=None, js_options=None):
         The number of digits of precision to display for floating-point
         values.  If unset, we use the value of
         `pandas.get_option('display.precision')`.
-    js_options : dict
+    grid_options : dict
         Options to use when creating javascript SlickGrid instances.  See
         the SlickGrid documentation for information on the available
         options.  Default options are as follows:
@@ -124,24 +123,24 @@ def show_grid(data_frame, remote_js=None, precision=None, js_options=None):
         precision = defaults.precision
         if not isinstance(precision, Integral):
             raise TypeError("precision must be int, not %s" % type(precision))
-    if js_options is None:
-        js_options = defaults.js_options
-        if not isinstance(js_options, DictType):
+    if grid_options is None:
+        grid_options = defaults.grid_options
+        if not isinstance(grid_options, dict):
             raise TypeError(
-                "js_options must be dict, not %s" % type(js_options)
+                "grid_options must be dict, not %s" % type(grid_options)
             )
 
     return SlickGrid(
         data_frame,
         remote_js=remote_js,
         precision=precision,
-        js_options=js_options,
+        grid_options=grid_options,
     )
 
 
 class SlickGrid(object):
 
-    def __init__(self, data_frame, remote_js, precision, js_options):
+    def __init__(self, data_frame, remote_js, precision, grid_options):
         self.data_frame = data_frame
         self.remote_js = remote_js
         self.div_id = str(uuid.uuid4())
@@ -168,7 +167,7 @@ class SlickGrid(object):
             self.column_types.append(column_type)
 
         self.precision = precision
-        self.js_options = js_options
+        self.grid_options = grid_options
 
     def _ipython_display_(self):
         try:
@@ -178,7 +177,7 @@ class SlickGrid(object):
                 date_format='iso',
                 double_precision=self.precision,
             )
-            options_json = json.dumps(self.js_options)
+            options_json = json.dumps(self.grid_options)
 
             if self.remote_js:
                 cdn_base_url = \

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -21,9 +21,13 @@ SLICK_GRID_CSS = template_contents('slickgrid.css.template')
 SLICK_GRID_JS = template_contents('slickgrid.js.template')
 
 
+def show_grid(data_frame, *args, **kwargs):
+    return SlickGrid(data_frame, *args, **kwargs)
+
+
 class SlickGrid(object):
 
-    def __init__(self, data_frame, remote_js=False):
+    def __init__(self, data_frame, remote_js=False, precision=None):
         self.data_frame = data_frame
         self.remote_js = remote_js
         self.div_id = str(uuid.uuid4())
@@ -49,7 +53,12 @@ class SlickGrid(object):
                     break
             self.column_types.append(column_type)
 
-        self.precision = pd.get_option('display.precision') - 1
+        if isinstance(precision, int) and precision>=0:
+            self.precision = precision
+        elif precision is None:
+            self.precision = pd.get_option('display.precision') - 1
+        else:
+            raise TypeError('precision')
 
     def _ipython_display_(self):
         try:

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -62,7 +62,7 @@ class _DefaultSettings(object):
         if precision is not None:
             self._precision = precision
         if js_options is not None:
-            self._js_options = None
+            self._js_options = js_options
 
     @property
     def js_options(self):

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -20,6 +20,15 @@ def template_contents(filename):
 SLICK_GRID_CSS = template_contents('slickgrid.css.template')
 SLICK_GRID_JS = template_contents('slickgrid.js.template')
 
+SLICK_GRID_DEFAULT_OPTIONS = {
+    'enableCellNavigation': True,
+    'fullWidthRows': True,
+    'syncColumnCellResize': True,
+    'forceFitColumns': True,
+    'rowHeight': 28,
+    'enableColumnReorder': False,
+    'enableTextSelectionOnCells': True, }
+
 
 def show_grid(data_frame, *args, **kwargs):
     return SlickGrid(data_frame, *args, **kwargs)
@@ -27,7 +36,8 @@ def show_grid(data_frame, *args, **kwargs):
 
 class SlickGrid(object):
 
-    def __init__(self, data_frame, remote_js=False, precision=None):
+    def __init__(self, data_frame, remote_js=False, precision=None,
+                 options={}):
         self.data_frame = data_frame
         self.remote_js = remote_js
         self.div_id = str(uuid.uuid4())
@@ -60,6 +70,11 @@ class SlickGrid(object):
         else:
             raise TypeError('precision')
 
+        if not isinstance(options, dict):
+            raise TypeError('options')
+        self.options = SLICK_GRID_DEFAULT_OPTIONS.copy()
+        self.options.update(options)
+
     def _ipython_display_(self):
         try:
             column_types_json = json.dumps(self.column_types)
@@ -68,6 +83,7 @@ class SlickGrid(object):
                 date_format='iso',
                 double_precision=self.precision,
             )
+            options_json = json.dumps(self.options)
 
             if self.remote_js:
                 cdn_base_url = \
@@ -84,6 +100,7 @@ class SlickGrid(object):
                 div_id=self.div_id,
                 data_frame_json=data_frame_json,
                 column_types_json=column_types_json,
+                options_json=options_json,
             )
 
             display_html(raw_html, raw=True)

--- a/qgrid/qgridjs/qgrid.js
+++ b/qgrid/qgridjs/qgrid.js
@@ -81,7 +81,7 @@ define([
     }, this);
   }
 
-  QGrid.prototype.initialize_slick_grid = function () {
+  QGrid.prototype.initialize_slick_grid = function (options) {
     this.data_view = new Slick.Data.DataView({
       inlineFilters: false,
       enableTextSelectionOnCells: true
@@ -93,16 +93,6 @@ define([
     this.data_view.setItems(this.row_data);
     this.data_view.setFilter($.proxy(this.include_row, this));
     this.data_view.endUpdate();
-
-    var options = {
-      enableCellNavigation: true,
-      fullWidthRows: true,
-      syncColumnCellResize: true,
-      forceFitColumns: true,
-      rowHeight: 28,
-      enableColumnReorder: false,
-      enableTextSelectionOnCells: true
-    };
 
     var max_height = options.rowHeight * 15;
     var grid_height = max_height;

--- a/qgrid/templates/slickgrid.js.template
+++ b/qgrid/templates/slickgrid.js.template
@@ -49,7 +49,7 @@ function($){{
     ], function(){{
         require(["data_grid"], function(dgrid){{
             var grid = new dgrid.QGrid('#{div_id}', {data_frame_json}, {column_types_json});
-            grid.initialize_slick_grid();
+            grid.initialize_slick_grid({options_json});
         }});
     }});
 }});


### PR DESCRIPTION
Built on top of https://github.com/quantopian/qgrid/pull/23.

Adds some documentation and two new public API methods: `set_defaults` and `set_js_option`.

`set_defaults` accepts all the same optional parameters as `show_grid`, and any values passed passed will be used as defaults to future `show_grid` calls.  This includes a new parameter, `js_options`, a dictionary of options that's JSON-formatted and templated into our generated html/javascript.

`set_js_option` allows users to override single Slickgrid options without having to re-copy the existing ones.

@snth I took most of what you had already implemented and made it so that you can globally configure all SlickGrid instances for a given session.  This would also pave the way for allowing reliable configuration of notebook base URLs.

Can you confirm that this still solves the issues that were being addressed in #23?