### PR TITLE
Prune redundant, invalid CSS

### DIFF
--- a/qgrid/qgridjs/qgrid.css
+++ b/qgrid/qgridjs/qgrid.css
@@ -128,8 +128,6 @@
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   padding-top: 3px;
   padding-left: 0px;
-  &.l0.r0
-   border-left: none;
 }
 
 .q-grid .slick-cell.l0.r0 {


### PR DESCRIPTION
The rule I removed

```css
&.l0.r0
  border-left: none;
```

is not valid CSS, but that rule is actually [validly specified in the next block of CSS](https://github.com/quantopian/qgrid/blob/master/qgrid/qgridjs/qgrid.css#L136).