### PR TITLE
Update grid.py

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -7,7 +7,7 @@ from numbers import Integral
 
 from IPython.display import display_html, display_javascript
 try:
-    from ipywidgets import widgets
+    import ipywidgets as widgets
 except ImportError:
     from IPython.html import widgets
 from IPython.display import display, Javascript


### PR DESCRIPTION
Wrong import was causing warnings with ipython 4.

/usr/local/lib/python2.7/dist-packages/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.
  "`IPython.html.widgets` has moved to `ipywidgets`.", ShimWarning)
Traceback (most recent call last):
  File "memsee.py", line 13, in <module>
    import qgrid
  File "/usr/local/lib/python2.7/dist-packages/qgrid/__init__.py", line 1, in <module>
    from .grid import (
  File "/usr/local/lib/python2.7/dist-packages/qgrid/grid.py", line 204, in <module>
    class QGridWidget(widgets.DOMWidget):
  File "/usr/local/lib/python2.7/dist-packages/IPython/utils/shimmodule.py", line 92, in __getattr__
    raise AttributeError(key)
AttributeError: DOMWidget