### PR TITLE
Allow update of Grid

### DIFF
--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,7 +1,8 @@
 from .grid import (
     set_defaults,
     set_grid_option,
-    show_grid
+    show_grid,
+    QGridWidget
 )
 
 
@@ -51,5 +52,5 @@ def nbinstall(overwrite=False, user=True):
         **({'user': user} if version_info >= (3, 0, 0, '') else {})
     )
 
-__all__ = ['set_defaults', 'set_grid_option', 'show_grid']
+__all__ = ['set_defaults', 'set_grid_option', 'show_grid', 'QGridWidget']
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -218,11 +218,13 @@ class QGridWidget(widgets.DOMWidget):
 
     def update_table(self):
         """Build the Data Table for the DataFrame."""
-
         df = self.df.copy()
 
         # register a callback for custom messages
         self.on_msg(self._handle_qgrid_msg)
+
+        if not df.index.name:
+            df.index.name = 'Index'
 
         if type(df.index) == pd.core.index.MultiIndex:
             df.reset_index(inplace=True)
@@ -230,9 +232,6 @@ class QGridWidget(widgets.DOMWidget):
         else:
             df.insert(0, df.index.name, df.index)
             self._multi_index = False
-
-        if not df.index.name:
-            df.index.name = 'Index'
 
         self._index_name = df.index.name
 
@@ -267,6 +266,7 @@ class QGridWidget(widgets.DOMWidget):
             )
 
         self._remote_js_changed()
+        self.send({'type': 'draw_table'})
 
     def _remote_js_changed(self):
         if self.remote_js:

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -269,7 +269,7 @@ class QGridWidget(widgets.DOMWidget):
             df.insert(0, df.index.name, df.index)
             self._multi_index = False
 
-        self._index_name = df.index.name
+        self._index_name = df.index.name or 'Index'
 
         tc = dict(np.typecodes)
         for key in np.typecodes.keys():

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -226,16 +226,16 @@ class QGridWidget(widgets.DOMWidget):
         self.on_msg(self._handle_qgrid_msg)
         self.update_table()
 
-    def _default_grid_options(self):
+    def _grid_options_default(self):
         return defaults.grid_options
 
-    def _default_remote_js(self):
+    def _remote_js_default(self):
         return defaults.remote_js
 
-    def _default_precision(self):
+    def _precision_default(self):
         return defaults.precision
 
-    def _default__cdn_base_url(self):
+    def __cdn_base_url_default(self):
         return REMOTE_URL if self.remote_js else "/nbextensions/qgridjs"
 
     def update_table(self):

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -31,6 +31,7 @@ SLICK_GRID_CSS = template_contents('slickgrid.css.template')
 SLICK_GRID_JS = template_contents('slickgrid.js.template')
 REMOTE_URL = ("https://cdn.rawgit.com/quantopian/qgrid/"
               "master/qgrid/qgridjs/")
+LOCAL_URL = "/nbextensions/qgridjs"
 
 
 class _DefaultSettings(object):
@@ -211,7 +212,7 @@ class QGridWidget(widgets.DOMWidget):
     _column_types_json = Unicode('', sync=True)
     _index_name = Unicode('')
     _dirty = Bool(False)
-    _cdn_base_url = Unicode("/nbextensions/qgridjs", sync=True)
+    _cdn_base_url = Unicode(LOCAL_URL, sync=True)
     _multi_index = Bool(False)
 
     df = Instance(pd.DataFrame)
@@ -234,9 +235,6 @@ class QGridWidget(widgets.DOMWidget):
 
     def _precision_default(self):
         return defaults.precision
-
-    def __cdn_base_url_default(self):
-        return REMOTE_URL if self.remote_js else "/nbextensions/qgridjs"
 
     def update_table(self):
         """Build the Data Table for the DataFrame."""
@@ -287,6 +285,7 @@ class QGridWidget(widgets.DOMWidget):
                 date_format='iso',
                 double_precision=self.precision,
             )
+        self._cdn_base_url = REMOTE_URL if self.remote_js else LOCAL_URL
         self._dirty = False
 
     def add_row(self, value=None):

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -224,7 +224,7 @@ class QGridWidget(widgets.DOMWidget):
         super(QGridWidget, self).__init__(*args, **kwargs)
         # register a callback for custom messages
         self.on_msg(self._handle_qgrid_msg)
-        self.update_table()
+        self._update_table()
 
     def _grid_options_default(self):
         return defaults.grid_options

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -43,6 +43,7 @@ class _DefaultSettings(object):
             'fullWidthRows': True,
             'syncColumnCellResize': True,
             'forceFitColumns': True,
+            'defaultColumnWidth': 150,
             'rowHeight': 28,
             'enableColumnReorder': False,
             'enableTextSelectionOnCells': True,
@@ -178,14 +179,18 @@ def show_grid(data_frame, remote_js=None, precision=None, grid_options=None,
         remote_js = defaults.remote_js
     if precision is None:
         precision = defaults.precision
-        if not isinstance(precision, Integral):
-            raise TypeError("precision must be int, not %s" % type(precision))
+    if not isinstance(precision, Integral):
+        raise TypeError("precision must be int, not %s" % type(precision))
     if grid_options is None:
         grid_options = defaults.grid_options
-        if not isinstance(grid_options, dict):
-            raise TypeError(
-                "grid_options must be dict, not %s" % type(grid_options)
-            )
+    else:
+        options = defaults.grid_options.copy()
+        options.update(grid_options)
+        grid_options = options
+    if not isinstance(grid_options, dict):
+        raise TypeError(
+            "grid_options must be dict, not %s" % type(grid_options)
+        )
 
     # create a visualization for the dataframe
     grid = QGridWidget(df=data_frame, precision=precision,

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -12,9 +12,11 @@ except ImportError:
     from IPython.html import widgets
 from IPython.display import display, Javascript
 try:
-    from traitlets import Unicode, Instance, Bool, Integer, Dict
+    from traitlets import Unicode, Instance, Bool, Integer, Dict, List
 except ImportError:
-    from IPython.utils.traitlets import Unicode, Instance, Bool, Integer, Dict
+    from IPython.utils.traitlets import (
+        Unicode, Instance, Bool, Integer, Dict, List
+    )
 
 
 def template_contents(filename):
@@ -215,6 +217,7 @@ class QGridWidget(widgets.DOMWidget):
     _dirty = Bool(False)
     _cdn_base_url = Unicode(LOCAL_URL, sync=True)
     _multi_index = Bool(False)
+    _selected_rows = List()
 
     df = Instance(pd.DataFrame)
     precision = Integer(6)
@@ -228,6 +231,7 @@ class QGridWidget(widgets.DOMWidget):
         # register a callback for custom messages
         self.on_msg(self._handle_qgrid_msg)
         self._initialized = True
+        self._selected_rows = []
         if self.df is not None:
             self._update_table()
 
@@ -337,6 +341,14 @@ class QGridWidget(widgets.DOMWidget):
                 self._dirty = True
             except ValueError:
                 pass
+
+        elif content['type'] == 'selection_change':
+            self._selected_rows = content['rows']
+            print(self._selected_rows)
+
+    def get_selected_rows(self):
+        """Get the currently selected rows"""
+        return self._selected_rows
 
     def export(self, value=None):
         if self._dirty:

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -211,6 +211,7 @@ class QGridWidget(widgets.DOMWidget):
     _df_json = Unicode('', sync=True)
     _column_types_json = Unicode('', sync=True)
     _index_name = Unicode('')
+    _initialized = Bool(False)
     _dirty = Bool(False)
     _cdn_base_url = Unicode(LOCAL_URL, sync=True)
     _multi_index = Bool(False)
@@ -222,10 +223,13 @@ class QGridWidget(widgets.DOMWidget):
 
     def __init__(self, *args, **kwargs):
         """Initialize all variables before building the table."""
+        self._initialized = False
         super(QGridWidget, self).__init__(*args, **kwargs)
         # register a callback for custom messages
         self.on_msg(self._handle_qgrid_msg)
-        self._update_table()
+        self._initialized = True
+        if self.df is not None:
+            self._update_table()
 
     def _grid_options_default(self):
         return defaults.grid_options
@@ -236,8 +240,10 @@ class QGridWidget(widgets.DOMWidget):
     def _precision_default(self):
         return defaults.precision
 
-    def update_table(self):
+    def _df_changed(self):
         """Build the Data Table for the DataFrame."""
+        if not self._initialized:
+            return
         self._update_table()
         self.send({'type': 'draw_table'})
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -74,6 +74,7 @@ class _DefaultSettings(object):
 
 defaults = _DefaultSettings()
 
+
 def set_defaults(remote_js=None, precision=None, grid_options=None):
     """
     Set the default qgrid options.  The options that you can set here are the
@@ -95,6 +96,7 @@ def set_defaults(remote_js=None, precision=None, grid_options=None):
     """
     defaults.set_defaults(remote_js, precision, grid_options)
 
+
 def set_grid_option(optname, optvalue):
     """
     Set the default value for one of the options that gets passed into the
@@ -115,7 +117,8 @@ def set_grid_option(optname, optvalue):
     <https://github.com/mleibman/SlickGrid/wiki/Grid-Options>`_ for the full
     list of available options.
     """
-    self._grid_options[optname] = optvalue
+    defaults._grid_options[optname] = optvalue
+
 
 def show_grid(data_frame, remote_js=None, precision=None, grid_options=None,
               show_toolbar=False):
@@ -185,7 +188,6 @@ def show_grid(data_frame, remote_js=None, precision=None, grid_options=None,
     grid = QGridWidget(df=data_frame, precision=precision,
                        grid_options=json.dumps(grid_options),
                        remote_js=remote_js)
-    grid.update_table()
 
     if show_toolbar:
         add_row = widgets.Button(description="Add Row")
@@ -214,7 +216,15 @@ class QGridWidget(widgets.DOMWidget):
     df = Instance(pd.DataFrame)
     precision = Integer(6)
     grid_options = Unicode('', sync=True)
-    remote_js = Bool(True)
+    remote_js = Bool(False)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize all variables before building the table."""
+        kwargs.setdefault('grid_options', json.dumps(defaults.grid_options))
+        kwargs.setdefault('precision', defaults.precision)
+        kwargs.setdefault('remote_js', defaults.remote_js)
+        super(QGridWidget, self).__init__(*args, **kwargs)
+        self.update_table()
 
     def update_table(self):
         """Build the Data Table for the DataFrame."""
@@ -264,8 +274,6 @@ class QGridWidget(widgets.DOMWidget):
                 date_format='iso',
                 double_precision=self.precision,
             )
-
-        self._remote_js_changed()
         self.send({'type': 'draw_table'})
 
     def _remote_js_changed(self):

--- a/qgrid/qgridjs/qgrid.css
+++ b/qgrid/qgridjs/qgrid.css
@@ -8,6 +8,7 @@
 .q-grid-container {
   position: relative;
   margin: 4px -5px;
+  overflow-x: scroll;
 }
 
 .q-grid {

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -96,8 +96,13 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
             table.addClass('q-grid');
             this.tableDiv = table[0];
 
-            // Make the table scroll horizontally.
-            this.el.setAttribute("style", "overflow-x: scroll");
+            // fill the portion of the widget area not in the prompt
+            var parent = this.el.parentElement;
+            while (parent.className !== 'widget-area') {
+                parent = parent.parentElement;
+            }
+            var width = (parent.clientWidth - parent.childNodes[0].clientWidth);
+            this.el.setAttribute("style", "max-width:" + String(width) + "px;");
         },
 
         /**

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -179,6 +179,7 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
 
             } else if (msg.type === 'draw_table') {
                 this.drawTable();
+                this.updateSize();
             }
         },
 

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -21,7 +21,7 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
                     "<link id='dg-css' href='" + cdn_base_url + "/qgrid.css' rel='stylesheet'>"
                 ]);
             }
-            
+
             var path_dictionary = {
                 jquery_drag: cdn_base_url + "/lib/jquery.event.drag-2.2",
                 slick_core: cdn_base_url + "/lib/slick.core.2.2",
@@ -54,11 +54,11 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
             require.config({
                 paths: path_dictionary
             });
-            
+
             if (typeof jQuery === 'function') {
                 define('jquery', function() { return jQuery; });
             }
-    
+
             /**
              * Load the required scripts and create the grid.
              */
@@ -72,25 +72,30 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
             ],
             function() {
                 require(['slick_grid'], function() {
-                    require(["data_grid", "editors"], 
-                        function(dgrid, editors) {
-                            that.setupQGrid(dgrid, editors);
-                    });
+                    require(["data_grid", "editors"],function(dgrid, editors) {
+                            that.setupTable(dgrid, editors);
+                            that.drawTable();
+                        }
+                    );
                 });
             });
         },
 
         /**
-         * Set up our QGrid and event handlers.
+         * Set up the table div.
          */
-        setupQGrid: function(dgrid, editors) {
-            var that = this;
+        setupTable: function(dgrid, editors) {
             this.dgrid = dgrid;
+            this.editors = editors;
+            // subscribe to incoming messages from the QGridWidget
+            this.model.on('msg:custom', this.handleMsg, this);
+
             // set up the divs and styles
             this.$el.addClass('q-grid-container');
             var table = this.$el.append('div');
             table.addClass('q-grid');
-            
+            this.tableDiv = table[0];
+
             // fill the portion of the widget area not in the prompt
             var parent = this.el.parentElement;
             while (parent.className !== 'widget-area') {
@@ -98,12 +103,20 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
             }
             var width = (parent.clientWidth - parent.childNodes[0].clientWidth);
             this.el.setAttribute("style", "max-width:" + String(width) + "px;");
+        },
+
+        /**
+         * Set up our QGrid and event handlers.
+         */
+        drawTable: function() {
+            var that = this;
+            var editors = this.editors;
 
             // create the table
             var df = JSON.parse(this.model.get('_df_json'));
             var column_types = JSON.parse(this.model.get('_column_types_json'));
             var options = JSON.parse(this.model.get('grid_options'));
-            grid = new dgrid.QGrid(table[0], df, column_types);
+            grid = new this.dgrid.QGrid(this.tableDiv, df, column_types);
             grid.initialize_slick_grid(options);
 
             // set up editing
@@ -132,11 +145,8 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
                            'value': args.item[column], 'type': 'cell_change'};
                 that.send(msg);
             });
-
-            // subscribe to incoming messages from the QGridWidget
-            this.model.on('msg:custom', this.handleMsg, this);
         },
-        
+
         /**
          * Handle messages from the QGridWidget.
          */
@@ -160,6 +170,9 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
                 dd.refresh();
                 this.updateSize();
                 this.send(msg);
+
+            } else if (msg.type === 'draw_table') {
+                this.drawTable();
             }
         },
 

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -145,6 +145,12 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
                            'value': args.item[column], 'type': 'cell_change'};
                 that.send(msg);
             });
+
+            sgrid.onSelectedRowsChanged.subscribe(function(e, args) {
+                var rows = args.rows;
+                var msg = {'rows': args.rows, 'type': 'selection_change'};
+                that.send(msg);
+            });
         },
 
         /**

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -96,13 +96,8 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
             table.addClass('q-grid');
             this.tableDiv = table[0];
 
-            // fill the portion of the widget area not in the prompt
-            var parent = this.el.parentElement;
-            while (parent.className !== 'widget-area') {
-                parent = parent.parentElement;
-            }
-            var width = (parent.clientWidth - parent.childNodes[0].clientWidth);
-            this.el.setAttribute("style", "max-width:" + String(width) + "px;");
+            // Make the table scroll horizontally.
+            this.el.setAttribute("style", "overflow-x: scroll");
         },
 
         /**

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -115,7 +115,7 @@ define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widge
             // create the table
             var df = JSON.parse(this.model.get('_df_json'));
             var column_types = JSON.parse(this.model.get('_column_types_json'));
-            var options = JSON.parse(this.model.get('grid_options'));
+            var options = this.model.get('grid_options');
             grid = new this.dgrid.QGrid(this.tableDiv, df, column_types);
             grid.initialize_slick_grid(options);
 


### PR DESCRIPTION
This allows a `QGridWidget` to be refreshed and makes it easier to use the widget directly if desired.  

Example:

```python
import qgrid
from IPython.html.widgets import Button, VBox
from IPython.display import display
import pandas as pd

pd.set_option('display.max_rows', 8)

from pandas.io.data import get_data_yahoo
spy = get_data_yahoo(
    symbols='SPY',
    start=pd.Timestamp('2011-01-01'),
    end=pd.Timestamp('2014-01-01'),
    adjust_price=True,
)
# use an integer index so we can add rows
spy = spy.reset_index()

qgrid.nbinstall(overwrite=True)
grid = qgrid.QGridWidget(df=spy)
button = Button(description='Update')

def update(button):
    new = get_data_yahoo(
        symbols='SPY',
        start=pd.Timestamp('2011-01-01'),
        end=pd.Timestamp('2014-01-01'),
        adjust_price=True,
    )
    grid.df = new
button.on_click(update)
    
display(VBox((button, grid)))
```

![qgrid_demo5](https://cloud.githubusercontent.com/assets/2096628/11769282/1c172b42-a1a9-11e5-87d9-878f7e904fdb.gif)
 
Also:
- Fixes the `Index` column title which used to be `null`.
- Allows allows one to programmatically get the currently selected rows.
- If the table overflows, it will now scroll horizontally instead of expanding past the end of the notebook (including an exported table).