### PR TITLE
remove print statement on selection_change event

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -349,7 +349,6 @@ class QGridWidget(widgets.DOMWidget):
 
         elif content['type'] == 'selection_change':
             self._selected_rows = content['rows']
-            print(self._selected_rows)
 
     def get_selected_rows(self):
         """Get the currently selected rows"""


### PR DESCRIPTION
The print statement, which was useful for debugging, is causing output every time the row selection is changed.