### PR TITLE
Minumum version instead of exact version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-notebook==4.1.0
-pandas==0.17.1
-ipywidgets==4.1.1
+notebook>=4.1.0
+pandas>=0.17.1
+ipywidgets>=4.1.1


### PR DESCRIPTION
This would stop `pip install qgrid` from uninstalling the latest version of a library, like pandas 0.18, to get an older one.