### PR TITLE
DOC: Added qgrid logo to README and docs index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. image:: https://media.quantopian.com/logos/open_source/qgrid-logo-03.png
+    :target: https://qgrid.readthedocs.io
+    :width: 190px
+    :align: center
+    :alt: qgrid
+
 =====
 qgrid
 =====

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,12 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. image:: https://media.quantopian.com/logos/open_source/qgrid-logo-03.png
+    :target: https://qgrid.readthedocs.io
+    :width: 190px
+    :align: center
+    :alt: qgrid
+
 Qgrid API Documentation
 =======================
 


### PR DESCRIPTION
Not sure how to have them share the directives instead of copying.  Let me know if there's a preferable method.