### PR TITLE
Make qgrid compatible with ipywidgets 5 and jupyter notebook 4.2.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,13 +52,26 @@ and will be automatically installed (if necessary) when qgrid is installed via p
 
 **Compatibility:**
 
-| qgrid           | IPython / Jupyter notebook | ipywidgets                   |
-| --------------- | -------------------------- | ---------------------------- |
-| 0.2.0           | 2.x                        | N/A                          |
-| 0.3.x, master   | 3.x                        | N/A                          |
-| 0.3.x, master   | 4.0                        | 4.0.x                        |
-| 0.3.x, master   | 4.1                        | 4.1.x                        |
-| master          | 4.2                        | 5.x                          |
+=================  ===========================  ==============================
+ qgrid             IPython / Jupyter notebook   ipywidgets
+-----------------  ---------------------------  ------------------------------
+ 0.2.0             2.x                          N/A
+ 0.3.x, master     3.x                          N/A
+ 0.3.x, master     4.0                          4.0.x
+ 0.3.x, master     4.1                          4.1.x
+ master            4.2                          5.x
+=================  ===========================  ==============================
+
+=====  =====  ======
+   Inputs     Output
+------------  ------
+  A      B    A or B
+=====  =====  ======
+False  False  False
+True   False  True
+False  True   True
+True   True   True
+=====  =====  ======
 
 **Installing from PyPI:**
 

--- a/README.rst
+++ b/README.rst
@@ -54,24 +54,13 @@ and will be automatically installed (if necessary) when qgrid is installed via p
 
 =================  ===========================  ==============================
  qgrid             IPython / Jupyter notebook   ipywidgets
------------------  ---------------------------  ------------------------------
+=================  ===========================  ==============================
  0.2.0             2.x                          N/A
  0.3.x, master     3.x                          N/A
  0.3.x, master     4.0                          4.0.x
  0.3.x, master     4.1                          4.1.x
  master            4.2                          5.x
 =================  ===========================  ==============================
-
-=====  =====  ======
-   Inputs     Output
-------------  ------
-  A      B    A or B
-=====  =====  ======
-False  False  False
-True   False  True
-False  True   True
-True   True   True
-=====  =====  ======
 
 **Installing from PyPI:**
 

--- a/README.rst
+++ b/README.rst
@@ -36,21 +36,29 @@ Qgrid runs on `Python 2 or 3 <https://www.python.org/downloads/>`_.  You'll also
 
 Qgrid depends on the following three Python packages:
 
-    `Jupyter notebook <https://github.com/jupyter/notebook>`_ (versions 4.0.0 - 4.1.0)
+    `Jupyter notebook <https://github.com/jupyter/notebook>`_
       This is the interactive Python environment in which qgrid runs.
 
-    `ipywidgets <https://github.com/ipython/ipywidgets>`_ (versions 4.0.0 - 4.1.1)
+    `ipywidgets <https://github.com/ipython/ipywidgets>`_
       In order for Jupyter notebooks to be able to run widgets, you have to also install this ipywidgets package.
       It's maintained by the Jupyter organization, the same people who created Jupyter notebook.
 
-    `Pandas <http://pandas.pydata.org/>`_ (version 0.17.1 and above)
+    `Pandas <http://pandas.pydata.org/>`_
       A powerful data analysis / manipulation library for Python.  Qgrid requires that the data to be rendered as an
       interactive grid be provided in the form of a pandas DataFrame.
 
 These are listed in `requirements.txt <https://github.com/quantopian/qgrid/blob/master/requirements.txt>`_
 and will be automatically installed (if necessary) when qgrid is installed via pip.
 
-\*\*\* Please note that qgrid is not yet compatible with Jupyter notebook 4.2.x or ipywidgets 5.x.x \*\*\*
+**Compatibility:**
+
+qgrid           | IPython / Jupyter notebook | ipywidgets                   |
+--------------- | -------------------------- | ---------------------------- |
+0.2.0           | 2.x                        | N/A                          |
+0.3.x, master   | 3.x                        | N/A                          |
+0.3.x, master   | 4.0                        | 4.0.x                        |
+0.3.x, master   | 4.1                        | 4.1.x                        |
+master          | 4.2                        | 5.x                          |
 
 **Installing from PyPI:**
 

--- a/README.rst
+++ b/README.rst
@@ -52,13 +52,13 @@ and will be automatically installed (if necessary) when qgrid is installed via p
 
 **Compatibility:**
 
-qgrid           | IPython / Jupyter notebook | ipywidgets                   |
---------------- | -------------------------- | ---------------------------- |
-0.2.0           | 2.x                        | N/A                          |
-0.3.x, master   | 3.x                        | N/A                          |
-0.3.x, master   | 4.0                        | 4.0.x                        |
-0.3.x, master   | 4.1                        | 4.1.x                        |
-master          | 4.2                        | 5.x                          |
+| qgrid           | IPython / Jupyter notebook | ipywidgets                   |
+| --------------- | -------------------------- | ---------------------------- |
+| 0.2.0           | 2.x                        | N/A                          |
+| 0.3.x, master   | 3.x                        | N/A                          |
+| 0.3.x, master   | 4.0                        | 4.0.x                        |
+| 0.3.x, master   | 4.1                        | 4.1.x                        |
+| master          | 4.2                        | 5.x                          |
 
 **Installing from PyPI:**
 

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -1,9 +1,12 @@
-if (IPython.version[0] !== '3') {
-    var path = 'nbextensions/widgets/'
+if (IPython.version[0] === '4' && parseInt(IPython.version[2]) >= 2) {
+    var path = 'jupyter-js-widgets';
 } else {
-    var path = ''
+    var path = 'widgets/js/widget';
+    if (IPython.version[0] !== '3') {
+        path = 'nbextensions/widgets/' + path;
+    }
 }
-define([path + "widgets/js/widget", path + "widgets/js/manager"], function(widget, manager) {
+define([path], function(widget) {
 
     var grid;
     var QGridView = widget.DOMWidgetView.extend({

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-notebook>=4.0.0,<=4.1.0
-pandas>=0.17.1
-ipywidgets>=4.0.0,<=4.1.1
+notebook>=4.0.0
+pandas>=0.16.2
+ipywidgets>=4.0.0


### PR DESCRIPTION
I'm also updating the README with a grid showing which versions of qgrid are compatible with which versions of jupyter notebook/ipywidgets.