### PR TITLE
Changes for 0.3.2 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,10 +56,10 @@ and will be automatically installed (if necessary) when qgrid is installed via p
  qgrid             IPython / Jupyter notebook   ipywidgets
 =================  ===========================  ==============================
  0.2.0             2.x                          N/A
- 0.3.x, master     3.x                          N/A
- 0.3.x, master     4.0                          4.0.x
- 0.3.x, master     4.1                          4.1.x
- master            4.2                          5.x
+ 0.3.x, 0.4.0      3.x                          N/A
+ 0.3.x, 0.4.0      4.0                          4.0.x
+ 0.3.x, 0.4.0      4.1                          4.1.x
+ 0.4.0             4.2                          5.x
 =================  ===========================  ==============================
 
 **Installing from PyPI:**

--- a/README.rst
+++ b/README.rst
@@ -56,10 +56,10 @@ and will be automatically installed (if necessary) when qgrid is installed via p
  qgrid             IPython / Jupyter notebook   ipywidgets
 =================  ===========================  ==============================
  0.2.0             2.x                          N/A
- 0.3.x, 0.4.0      3.x                          N/A
- 0.3.x, 0.4.0      4.0                          4.0.x
- 0.3.x, 0.4.0      4.1                          4.1.x
- 0.4.0             4.2                          5.x
+ 0.3.x             3.x                          N/A
+ 0.3.x             4.0                          4.0.x
+ 0.3.x             4.1                          4.1.x
+ 0.3.2             4.2                          5.x
 =================  ===========================  ==============================
 
 **Installing from PyPI:**

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ reqs = read_requirements('requirements.txt')
 
 setup(
     name='qgrid',
-    version='0.4.0',
+    version='0.3.2',
     description='A Pandas DataFrame viewer for IPython Notebook.',
     author='Quantopian Inc.',
     author_email='tshawver@quantopian.com',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ reqs = read_requirements('requirements.txt')
 
 setup(
     name='qgrid',
-    version='0.3.0',
+    version='0.4.0',
     description='A Pandas DataFrame viewer for IPython Notebook.',
     author='Quantopian Inc.',
     author_email='tshawver@quantopian.com',


### PR DESCRIPTION
@ssanderson I merged a fix over the weekend https://github.com/quantopian/qgrid/commit/509b303337bee8dac39b78c035a065e47b72e70f which makes qgrid compatible with ipywidgets 5+ and jupyter notebook 4.2.x (it previously was not, which I found out through this issue https://github.com/quantopian/qgrid/issues/75).

Could you try out master locally and make sure it works for you, and if everything looks good, merge this PR, tag a release with v0.4.0, and upload it to pypi? I didn't want to tag a release until someone else tried it out locally, since last time we needed some additional changes and I had to delete the release and retag it.  I can add the release notes once you merge this PR and create the tag.