### PR TITLE
Export current view

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -235,7 +235,6 @@ class QGridWidget(widgets.DOMWidget):
     _cdn_base_url = Unicode(LOCAL_URL, sync=True)
     _multi_index = Bool(False)
     _selected_rows = List()
-    _export_df = None
     _export_callback = None
 
     df = Instance(pd.DataFrame)
@@ -363,12 +362,10 @@ class QGridWidget(widgets.DOMWidget):
 
         elif content['type'] == 'selection_change':
             self._selected_rows = content['rows']
-        elif content['type'] == 'export_row':
-            row = pd.DataFrame.from_records([content['row']], index='Index')
-            self._export_df = self._export_df.append(row, ignore_index=True, verify_integrity=True)
-        elif content['type'] == 'export_done':
+
+        elif content['type'] == 'export_data':
             if self._export_callback:
-                self._export_callback(self._export_df)
+                self._export_callback(pd.DataFrame(content['data']))
 
     def get_selected_rows(self):
         """Get the currently selected rows"""
@@ -403,10 +400,8 @@ class QGridWidget(widgets.DOMWidget):
     # either a dataframe containing the data, or None if an error occurred
     def export_view(self, callback):
         self._export_callback = callback
-        self._export_df = pd.DataFrame()
         self.send({ 'type' : 'export_view' })
 
     def export_all(self, callback):
         self._export_callback = callback
-        self._export_df = pd.DataFrame()
         self.send({ 'type' : 'export_all' })

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -191,7 +191,31 @@ define([path], function(widget) {
             } else if (msg.type === 'draw_table') {
                 this.drawTable();
                 this.updateSize();
+            } 
+            // jchuahtacc: handle export_view message
+            else if (msg.type === 'export_view') {
+                this.exportView();
+            } else if (msg.type === 'export_all') {
+                this.exportView(true);
             }
+        },
+
+        /**
+         * jchuahtacc: retrieve "included" items from grid.data_view and send them back as messages
+         */
+        exportView: function(all) {
+            for (var i in grid.row_data) {
+                var row = grid.row_data[i];
+                if (all || row.include) {
+                    var data = { };
+                    for (var j in grid.columns) {
+                        var field = grid.columns[j].field;
+                        data[field] = row[field];
+                    }
+                    this.send({'type': 'export_row', 'row': data }); 
+                }
+            }
+            this.send({ 'type': 'export_done' });
         },
 
         /**

--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -204,6 +204,7 @@ define([path], function(widget) {
          * jchuahtacc: retrieve "included" items from grid.data_view and send them back as messages
          */
         exportView: function(all) {
+            results = [ ];
             for (var i in grid.row_data) {
                 var row = grid.row_data[i];
                 if (all || row.include) {
@@ -212,10 +213,10 @@ define([path], function(widget) {
                         var field = grid.columns[j].field;
                         data[field] = row[field];
                     }
-                    this.send({'type': 'export_row', 'row': data }); 
+                    results.push(data);
                 }
             }
-            this.send({ 'type': 'export_done' });
+            this.send({ 'type': 'export_data', 'data' : results });
         },
 
         /**

--- a/qgrid_export_view_demo.ipynb
+++ b/qgrid_export_view_demo.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import qgrid\n",
+    "\n",
+    "df = pd.DataFrame(np.random.randn(6,4),\n",
+    "    index=list('abcdef'),\n",
+    "    columns=list('ABCD'))\n",
+    "\n",
+    "grid = qgrid.show_grid(df, show_toolbar=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "filtered = None\n",
+    "def callback(df):\n",
+    "    global filtered\n",
+    "    filtered = df\n",
+    "    \n",
+    "grid.export_view(callback)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>A</th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>D</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.47940</td>\n",
+       "      <td>-0.94475</td>\n",
+       "      <td>-1.20880</td>\n",
+       "      <td>0.95058</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.97422</td>\n",
+       "      <td>1.40290</td>\n",
+       "      <td>-1.40673</td>\n",
+       "      <td>0.53463</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         A        B        C        D\n",
+       "0  0.47940 -0.94475 -1.20880  0.95058\n",
+       "1  1.97422  1.40290 -1.40673  0.53463"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filtered"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "widgets": {
+   "state": {
+    "4fb1b18b2a55454eb6302229de167090": {
+     "views": [
+      {
+       "cell_index": 0
+      }
+     ]
+    },
+    "9c7bbc47a63a4201ae3a3312405a489b": {
+     "views": [
+      {
+       "cell_index": 0
+      }
+     ]
+    },
+    "bce66d801410466eb2a74f557d1c1150": {
+     "views": [
+      {
+       "cell_index": 0
+      }
+     ]
+    }
+   },
+   "version": "1.2.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Added export_view function to QGridWidget to export all data currently being viewed (excluding any rows that have been filtered) to a new dataframe.

Also added export_all which exports all rows, regardless of filtered status.

Both functions take a callback, which will be passed a dataframe with requested rows. Indexes are not preserved.

This is in response to Issue #87 - Feature Request: Return visible rows when grid is filtered