### PR TITLE
Use jupypter-pip to install notebook extension js automatically during setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 notebook>=4.0.0
 pandas>=0.16.2
 ipywidgets>=4.0.0
+jupyter-pip>=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,12 @@ from os.path import (
     join, dirname, abspath
 )
 
+#jchuahtacc
+try:
+    from jupyterpip import cmdclass
+except:
+    import pip, importlib
+    pip.main(['install', 'jupyter-pip']); cmdclass = importlib.import_module('jupyterpip').cmdclass
 
 def read_requirements(basename):
     reqs_file = join(dirname(abspath(__file__)), basename)
@@ -50,5 +56,6 @@ setup(
         'Topic :: Scientific/Engineering :: Information Analysis',
         ],
     install_requires=reqs,
-    url="https://github.com/quantopian/qgrid"
+    url="https://github.com/quantopian/qgrid",
+    cmdclass=cmdclass('qgrid/qgridjs'),
 )


### PR DESCRIPTION
Automatically installs qgridjs to nbextensions using jupyter-pip. No need for separate nbinstall function call.