### PR TITLE
show_grid: returns grid object for further processing

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -219,6 +219,7 @@ def show_grid(data_frame, show_toolbar=None, remote_js=None, precision=None, gri
         display(widgets.HBox((add_row, rem_row, export)), grid)
     else:
         display(grid)
+    return grid
 
 
 class QGridWidget(widgets.DOMWidget):


### PR DESCRIPTION
I just want to use get_selected_rows() after showing the data frame.