### PR TITLE
fix unsafe script error for jqueryui css

### DIFF
--- a/qgrid/templates/slickgrid.css.template
+++ b/qgrid/templates/slickgrid.css.template
@@ -3,7 +3,7 @@ if ($("#dg-css").length == 0){{
     $("head").append([
         "<link href='{cdn_base_url}/lib/slick.grid.css' rel='stylesheet'>",
         "<link href='{cdn_base_url}/lib/slick-default-theme.css' rel='stylesheet'>",
-        "<link href='http://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/css/jquery-ui.min.css' rel='stylesheet'>",
+        "<link href='//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/css/jquery-ui.min.css' rel='stylesheet'>",
         "<link id='dg-css' href='{cdn_base_url}/qgrid.css' rel='stylesheet'>"
     ]);
 }}


### PR DESCRIPTION
I get a Mixed Content error when Jupyter is running over HTTPs.

https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content

The solution is to not hard-code HTTP in the URL. Tested locally, both on HTTP and HTTPs.