### PR TITLE
Fix version check to be compatible with IPython 5.0

### DIFF
--- a/qgrid/qgridjs/qgrid.widget.js
+++ b/qgrid/qgridjs/qgrid.widget.js
@@ -1,4 +1,4 @@
-if (IPython.version[0] === '4' && parseInt(IPython.version[2]) >= 2) {
+if (parseInt(IPython.version[0]) >= 5 || (IPython.version[0] === '4' && parseInt(IPython.version[2]) >= 2)) {
     var path = 'jupyter-js-widgets';
 } else {
     var path = 'widgets/js/widget';


### PR DESCRIPTION
show_grid fails for IPython 5.0 due to wrong JS widget path being used