### PR TITLE
Fix issue that was causing grid to double render

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -227,13 +227,13 @@ def show_grid(data_frame, show_toolbar=None, remote_js=None, precision=None, gri
         export = widgets.Button(description="Export")
         export.on_click(grid.export)
 
-        display(widgets.HBox((add_row, rem_row, export)), grid)
+        return widgets.VBox([widgets.HBox([add_row, rem_row, export]), grid])
     else:
         if export_mode:
             grid.export()
+            return None
         else:
-            display(grid)
-    return grid
+            return grid
 
 class QGridWidget(widgets.DOMWidget):
     _view_module = Unicode("nbextensions/qgridjs/qgrid.widget", sync=True)


### PR DESCRIPTION
Fixes https://github.com/quantopian/qgrid/issues/111

A while back I merged this PR: https://github.com/quantopian/qgrid/pull/100, which made it so we return the QgridWidget object from `show_grid`.  That caused the grid to double-render, since returning a widget causes it to be automatically rendered, and we were also still explicitly calling display.  This change removes the call to display in favor of returning whatever widget object was constructed (or None when exporting to static html, since there is no widget in that case).