### PR TITLE
Make it possible to set value of float cell to zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 
 # pytest
 .cache/*
+.pytest_cache/*
 
 # Jupyter notebook
 jupyterhub.sqlite

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qgrid",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An Interactive Grid for Sorting and Filtering DataFrames in Jupyter Notebook",
   "author": "Quantopian Inc.",
   "main": "src/index.js",

--- a/js/package.json
+++ b/js/package.json
@@ -34,7 +34,7 @@
     "jquery-ui-dist": "1.12.1",
     "json-loader": "^0.5.4",
     "moment": "^2.18.1",
-    "slickgrid-qgrid": "0.0.4",
+    "slickgrid-qgrid": "0.0.5",
     "style-loader": "^0.18.2",
     "underscore": "^1.8.3"
   },

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -36,8 +36,8 @@ class QgridModel extends widgets.DOMWidgetModel {
       _view_name : 'QgridView',
       _model_module : 'qgrid',
       _view_module : 'qgrid',
-      _model_module_version : '^1.0.1',
-      _view_module_version : '^1.0.1',
+      _model_module_version : '^1.0.2',
+      _view_module_version : '^1.0.2',
       _df_json: '',
       _columns: {}
     });

--- a/qgrid/_version.py
+++ b/qgrid/_version.py
@@ -1,4 +1,4 @@
-version_info = (1, 0, 1, 'final')
+version_info = (1, 0, 2, 'final')
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -223,6 +223,7 @@ def show_grid(data_frame, show_toolbar=None,
 
 PAGE_SIZE = 100
 
+
 @widgets.register()
 class QgridWidget(widgets.DOMWidget):
     """
@@ -396,7 +397,7 @@ class QgridWidget(widgets.DOMWidget):
         # for filters, and the state we return to when filters are removed
         self._unfiltered_df = self._df.copy()
 
-        self._update_table(update_columns=True)
+        self._update_table(update_columns=True, fire_data_change_event=False)
         self._ignore_df_changed = False
 
     def _rebuild_widget(self):
@@ -424,8 +425,11 @@ class QgridWidget(widgets.DOMWidget):
             return
         self._rebuild_widget()
 
-    def _update_table(self, update_columns=False, triggered_by=None,
-                      scroll_to_row=None):
+    def _update_table(self,
+                      update_columns=False,
+                      triggered_by=None,
+                      scroll_to_row=None,
+                      fire_data_change_event=True):
         df = self._df.copy()
 
         from_index = max(self._viewport_range[0] - PAGE_SIZE, 0)
@@ -537,7 +541,7 @@ class QgridWidget(widgets.DOMWidget):
                                       double_precision=self.precision)
 
         self._df_json = df_json
-        if not update_columns:
+        if fire_data_change_event:
             data_to_send = {
                 'type': 'update_data_view',
                 'columns': self._columns,

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -334,8 +334,8 @@ class QgridWidget(widgets.DOMWidget):
     _model_name = Unicode('QgridModel').tag(sync=True)
     _view_module = Unicode('qgrid').tag(sync=True)
     _model_module = Unicode('qgrid').tag(sync=True)
-    _view_module_version = Unicode('1.0.1').tag(sync=True)
-    _model_module_version = Unicode('1.0.1').tag(sync=True)
+    _view_module_version = Unicode('1.0.2').tag(sync=True)
+    _model_module_version = Unicode('1.0.2').tag(sync=True)
 
     _df = Instance(pd.DataFrame)
     _df_json = Unicode('', sync=True)


### PR DESCRIPTION
The fix is actually in our fork of the SlickGrid repository, here: https://github.com/quantopian/SlickGrid/commit/c672f35c105b113da12f2766193f12e5ca05312f

The fix in this repo was just to bump the version of slickgrid-qgrid in our package.json. Fixes #174.

Additional changes:
- Added python test cases for making sure editing floats works (they passed before this fix since this was a javascript problem).
- Updated tests to be python 2 compatible by removing usages of `nonlocal` (as requested in https://github.com/conda-forge/qgrid-feedstock/pull/3)