### PR TITLE
Enabled programmatic edits to grid and additional configuration options for columns and rows

### DIFF
--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -517,6 +517,11 @@ class QgridView extends widgets.DOMWidgetView {
               result = true;
             }
             result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
+        } else if (op == 'NOR') {
+            if (result == null) {
+              result = false;
+            }
+            result = result || !evaluateRowEditConditions(current_row, {'OR': obj[op]});
         } else {
           alert("Unsupported operation '" + op + "' found in row edit conditions!")
         }

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -484,7 +484,7 @@ class QgridView extends widgets.DOMWidgetView {
 
     // set up callbacks
 
-    // evaluate conditions under which cells should be disabled -- this occurs on a per-row basis, i.e.,
+    // evaluate conditions under which cells in a row should be disabled (contingent on values of other cells in the same row)
     var evaluateRowEditConditions = function(current_row, obj) {
       var result;
 
@@ -493,36 +493,39 @@ class QgridView extends widgets.DOMWidgetView {
             if (result == null) {
               result = true;
             }
-            var and_result = true;
+            //var and_result = true;
             for (var cond in obj[op]) {
               if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
-                and_result = and_result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+                result = result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
               } else {
-                and_result = and_result && (current_row[cond] == obj[op][cond]);
+                result = result && (current_row[cond] == obj[op][cond]);
               }
             }
-            result = result && and_result;
         } else if (op == 'OR') {
           if (result == null) {
             result = false;
           }
           var or_result = false;
           for (var cond in obj[op]) {
-              if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
-                or_result = or_result || evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+              if (cond == 'AND' || cond == 'OR' || cond == 'NAND' || cond == 'NOR') {
+                result = result || evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
               } else {
-                or_result = or_result || (current_row[cond] == obj[op][cond]);
+                result = result || (current_row[cond] == obj[op][cond]);
               }
             }
-            result = result || or_result;
-
-        } else if (op == 'NOT') {
+        } else if (op == 'NAND') {
             if (result == null) {
               result = true;
             }
             result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
+        } else if (op == 'NOR') {
+            if (result == null) {
+              result = true;
+            }
+            result = result && !evaluateRowEditConditions(current_row, {'OR': obj[op]});
+
         } else {
-          alert("Unsupported operation '" + op + "' found in cell edit conditions!")
+          alert("Unsupported operation '" + op + "' found in row edit conditions!")
         }
       }
       return result;

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -493,7 +493,6 @@ class QgridView extends widgets.DOMWidgetView {
             if (result == null) {
               result = true;
             }
-            //var and_result = true;
             for (var cond in obj[op]) {
               if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
                 result = result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
@@ -518,12 +517,6 @@ class QgridView extends widgets.DOMWidgetView {
               result = true;
             }
             result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
-        } else if (op == 'NOR') {
-            if (result == null) {
-              result = true;
-            }
-            result = result && !evaluateRowEditConditions(current_row, {'OR': obj[op]});
-
         } else {
           alert("Unsupported operation '" + op + "' found in row edit conditions!")
         }
@@ -741,6 +734,12 @@ class QgridView extends widgets.DOMWidgetView {
           'type': 'selection_change'
         });
       }, 100);
+    } else if (msg.type == 'toggle_editable') {
+        if (this.slick_grid.getOptions().editable == false) {
+          this.slick_grid.setOptions({'editable': true});
+        } else {
+          this.slick_grid.setOptions({'editable': false});
+        }
     } else if (msg.col_info) {
       var filter = this.filters[msg.col_info.name];
       filter.handle_msg(msg);

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -203,6 +203,8 @@ class QgridView extends widgets.DOMWidgetView {
     var columns = this.model.get('_columns');
     this.data_view = this.create_data_view(df_json.data);
     this.grid_options = this.model.get('grid_options');
+    this.column_definitions = this.model.get('column_definitions');
+    this.row_edit_conditions = this.model.get('row_edit_conditions');
     this.index_col_name = this.model.get("_index_col_name");
 
     this.columns = [];
@@ -321,7 +323,8 @@ class QgridView extends widgets.DOMWidgetView {
         id: cur_column.name,
         sortable: false,
         resizable: true,
-        cssClass: cur_column.type
+        cssClass: cur_column.type,
+        toolTip: cur_column.toolTip
       };
 
       Object.assign(slick_column, type_info);
@@ -345,10 +348,17 @@ class QgridView extends widgets.DOMWidgetView {
       // don't allow editing index columns
       if (cur_column.is_index) {
         slick_column.editor = editors.IndexEditor;
-        slick_column.cssClass += ' idx-col';
+        if (this.grid_options.boldIndex) {
+            slick_column.cssClass += ' idx-col';
+        }
         this.index_columns.push(slick_column);
         continue;
       }
+
+      if ( ! (cur_column.editable) ) {
+        slick_column.editor = null;
+      }
+
       this.columns.push(slick_column);
     }
 
@@ -473,6 +483,59 @@ class QgridView extends widgets.DOMWidgetView {
     });
 
     // set up callbacks
+
+    // evaluate conditions under which cells should be disabled -- this occurs on a per-row basis, i.e.,
+    var evaluateRowEditConditions = function(current_row, obj) {
+      var result;
+
+      for (var op in obj) {
+        if (op == 'AND') {
+            if (result == null) {
+              result = true;
+            }
+            var and_result = true;
+            for (var cond in obj[op]) {
+              if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
+                and_result = and_result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+              } else {
+                and_result = and_result && (current_row[cond] == obj[op][cond]);
+              }
+            }
+            result = result && and_result;
+        } else if (op == 'OR') {
+          if (result == null) {
+            result = false;
+          }
+          var or_result = false;
+          for (var cond in obj[op]) {
+              if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
+                or_result = or_result || evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+              } else {
+                or_result = or_result || (current_row[cond] == obj[op][cond]);
+              }
+            }
+            result = result || or_result;
+
+        } else if (op == 'NOT') {
+            if (result == null) {
+              result = true;
+            }
+            result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
+        } else {
+          alert("Unsupported operation '" + op + "' found in cell edit conditions!")
+        }
+      }
+      return result;
+    }
+
+    if ( ! (this.row_edit_conditions == null)) {
+        var conditions = this.row_edit_conditions;
+        var grid = this.slick_grid;
+        this.slick_grid.onBeforeEditCell.subscribe(function(e, args) {
+            return evaluateRowEditConditions(grid.getDataItem(args.row), conditions);
+        });
+    }
+
     this.slick_grid.onCellChange.subscribe((e, args) => {
       var column = this.columns[args.cell].name;
       var data_item = this.slick_grid.getDataItem(args.row);

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -38,7 +38,12 @@ class _DefaultSettings(object):
             'sortable': True,
             'filterable': True,
             'highlightSelectedCell': False,
-            'highlightSelectedRow': True
+            'highlightSelectedRow': True,
+            'boldIndex': True
+        }
+        self._column_options = {
+            'editable': True,
+            'toolTip': "",
         }
         self._show_toolbar = False
         self._precision = None  # Defer to pandas.get_option
@@ -47,13 +52,15 @@ class _DefaultSettings(object):
         self._grid_options[optname] = optvalue
 
     def set_defaults(self, show_toolbar=None, precision=None,
-                     grid_options=None):
+                     grid_options=None, column_options=None):
         if show_toolbar is not None:
             self._show_toolbar = show_toolbar
         if precision is not None:
             self._precision = precision
         if grid_options is not None:
             self._grid_options = grid_options
+        if column_options is not None:
+            self._column_options = column_options
 
     @property
     def show_toolbar(self):
@@ -67,11 +74,15 @@ class _DefaultSettings(object):
     def precision(self):
         return self._precision or pd.get_option('display.precision') - 1
 
+    @property
+    def column_options(self):
+        return self._column_options
+
 
 defaults = _DefaultSettings()
 
 
-def set_defaults(show_toolbar=None, precision=None, grid_options=None):
+def set_defaults(show_toolbar=None, precision=None, grid_options=None, column_options=None):
     """
     Set the default qgrid options.  The options that you can set here are the
     same ones that you can pass into ``QgridWidget`` constructor, with the
@@ -94,7 +105,7 @@ def set_defaults(show_toolbar=None, precision=None, grid_options=None):
         The widget whose default behavior is changed by ``set_defaults``.
     """
     defaults.set_defaults(show_toolbar=show_toolbar, precision=precision,
-                          grid_options=grid_options)
+                          grid_options=grid_options, column_options=column_options)
 
 
 def set_grid_option(optname, optvalue):
@@ -166,7 +177,9 @@ def disable():
 
 
 def show_grid(data_frame, show_toolbar=None,
-              precision=None, grid_options=None):
+              precision=None, grid_options=None,
+              column_options=None, column_definitions=None,
+              row_edit_conditions=None):
     """
     Renders a DataFrame or Series as an interactive qgrid, represented by
     an instance of the ``QgridWidget`` class.  The ``QgridWidget`` instance
@@ -196,6 +209,12 @@ def show_grid(data_frame, show_toolbar=None,
         precision = defaults.precision
     if not isinstance(precision, Integral):
         raise TypeError("precision must be int, not %s" % type(precision))
+    if column_options is None:
+        column_options = defaults.column_options
+    else:
+        options = defaults.column_options.copy()
+        options.update(column_options)
+        column_options = options
     if grid_options is None:
         grid_options = defaults.grid_options
     else:
@@ -218,6 +237,9 @@ def show_grid(data_frame, show_toolbar=None,
     # create a visualization for the dataframe
     return QgridWidget(df=data_frame, precision=precision,
                        grid_options=grid_options,
+                       column_options=column_options,
+                       column_definitions=column_definitions,
+                       row_edit_conditions=row_edit_conditions,
                        show_toolbar=show_toolbar)
 
 
@@ -364,6 +386,9 @@ class QgridWidget(widgets.DOMWidget):
     df = Instance(pd.DataFrame)
     precision = Integer(6, sync=True)
     grid_options = Dict(sync=True)
+    column_options = Dict(sync=True)
+    column_definitions = Dict({})
+    row_edit_conditions = Dict(sync=True)
     show_toolbar = Bool(False, sync=True)
 
     def __init__(self, *args, **kwargs):
@@ -506,6 +531,10 @@ class QgridWidget(widgets.DOMWidget):
 
                 cur_column['position'] = i
                 columns[col_name] = cur_column
+
+                columns[col_name].update(self.column_options)
+                if col_name in self.column_definitions.keys():
+                    columns[col_name].update(self.column_definitions[col_name])
 
             self._columns = columns
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -234,6 +234,9 @@ def show_grid(data_frame, show_toolbar=None,
             "data_frame must be DataFrame or Series, not %s" % type(data_frame)
         )
 
+    row_edit_conditions = (row_edit_conditions or {})
+    column_definitions = (column_definitions or {})
+
     # create a visualization for the dataframe
     return QgridWidget(df=data_frame, precision=precision,
                        grid_options=grid_options,
@@ -1091,7 +1094,7 @@ class QgridWidget(widgets.DOMWidget):
             df.loc[index_col_val, col_names[i]] = s
             self._unfiltered_df.loc[index_col_val, col_names[i]] = s
 
-        self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val))
+        self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val), fire_data_change_event=True)
         self._trigger_df_change_event()
 
     def remove_row(self):

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1061,6 +1061,39 @@ class QgridWidget(widgets.DOMWidget):
                            scroll_to_row=df.index.get_loc(last.name))
         self._trigger_df_change_event()
 
+    def add_row_internally(self, row):
+        """
+        Append a new row to the end of the dataframe given a list of 2-tuples of (column name, column value).
+        This feature will work for dataframes with arbitrary index types.
+        """
+        df = self._df
+
+        col_names, col_data = zip(*row)
+        col_names = list(col_names)
+        col_data = list(col_data)
+        index_col_val = dict(row)[df.index.name]
+
+        # check that the given column names match what already exists in the dataframe
+        required_cols = set(df.columns.values).union({df.index.name}) - {self._index_col_name}
+        if set(col_names) != required_cols:
+            msg = "Cannot add row -- column names don't match in the existing dataframe"
+            self.send({
+                'type': 'show_error',
+                'error_msg': msg,
+                'triggered_by': 'add_row'
+            })
+            return
+
+        for i, s in enumerate(col_data):
+            if col_names[i] == df.index.name:
+                continue
+
+            df.loc[index_col_val, col_names[i]] = s
+            self._unfiltered_df.loc[index_col_val, col_names[i]] = s
+
+        self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val))
+        self._trigger_df_change_event()
+
     def remove_row(self):
         """
         Remove the current row from the table.

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1097,6 +1097,12 @@ class QgridWidget(widgets.DOMWidget):
         self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val), fire_data_change_event=True)
         self._trigger_df_change_event()
 
+    def set_value_internally(self, index, column, value):
+        self._df.loc[index, column] = value
+        self._unfiltered_df.loc[index, column] = value
+        self._update_table(triggered_by='cell_change', fire_data_change_event=True)
+        self._trigger_df_change_event()
+
     def remove_row(self):
         """
         Remove the current row from the table.

--- a/qgrid/tests/test_grid.py
+++ b/qgrid/tests/test_grid.py
@@ -409,3 +409,33 @@ def test_object_dtype_categorical():
     })
     assert len(widget._df) == 1
     assert widget._df[0][0] == cat_series[0]
+
+
+def test_add_row_internally():
+    df = pd.DataFrame({'foo': ['hello'], 'bar': ['world'], 'baz': [42], 'boo': [57]})
+    df.set_index('baz', inplace=True, drop=True)
+
+    q = QgridWidget(df=df)
+
+    new_row = [
+        ('baz', 43),
+        ('bar', "new bar"),
+        ('boo', 58),
+        ('foo', "new foo")
+    ]
+
+    q.add_row_internally(new_row)
+
+    assert q._df.loc[43, 'foo'] == 'new foo'
+    assert q._df.loc[42, 'foo'] == 'hello'
+
+
+def test_set_value_internally():
+    df = pd.DataFrame({'foo': ['hello'], 'bar': ['world'], 'baz': [42], 'boo': [57]})
+    df.set_index('baz', inplace=True, drop=True)
+
+    q = QgridWidget(df=df)
+
+    q.set_value_internally(42, 'foo', 'hola')
+
+    assert q._df.loc[42, 'foo'] == 'hola'


### PR DESCRIPTION
Hello!  First of all I just want to say thanks for this great widget.  I took it upon myself to add a few features that I thought would be useful for a few particular use cases for a project that I'm currently working on at my job, and was hoping to get some feedback on them and possibly contribute the changes back if they might useful to other qgrid users.  

The rationale behind many of these features can be described in terms of two different needs: 1) the ability to programmatically update values in the grid while also avoiding completely resetting the entire dataframe (which causes some flickering of the UI when it is redrawn); and 2) conditionally and dynamically setting which parts of the grid can be edited at a given time.  Below is a summary of the added functionality:
- Implemented a "toggle_editable" message type that can be sent to the widget front end to enable/disable edits to the entire grid dynamically
- Implemented two internal update methods, set_value_internally() and add_row_internally(), which are intended for programmatically setting the value of a cell and programmatically adding a row, respectively.  The add_row_internally() method can add rows to a dataframe with an arbitrary index type (i.e., not limited to integer-only indexes)
- Added a grid option for conditionally bolding the index values
- Added column-specific options (editable, toolTip) which are specified using a dictionary of (column name, column options dictionary) pairs
- Implemented dynamic conditional editing of a row based on the content of the row in question

Below are some examples demonstrating how to use these features:

```
from qgrid import show_grid
import pandas as pd
from IPython.display import display

# row edit conditions grammar:
# ROW EDIT CONDITIONS => dict([ROW EDIT CONDITION])
# ROW EDIT CONDITION => (BOOLEAN OPERATOR, dict([(COLUMN NAME, COLUMN VALUE)]))
# BOOLEAN OPERATOR => AND | OR | NAND | NOR
# COLUMN NAME => <string>  
# COLUMN VALUE => <column dtype>
row_edit_conditions = {  # This set of conditions will cause any row where foo == 'hello' and bar == 'world' to have editing disabled
    'NAND': {
        'foo': 'hello',
        'bar': 'world'
    }
}

column_defs = {
    'foo': {
        'editable': True,
        'toolTip': "Editable"
    },
    'bar': {
        'editable': False,
        'toolTip': "Not editable"
    }
}

grid_options = {
    'boldIndex': False
}

df = pd.DataFrame({'foo': ['boo'], 'bar': ['world'], 'baz': [42], 'boo': [57]})
df.set_index('baz', inplace=True, drop=True)

q = show_grid(df, grid_options=grid_options, column_definitions=column_defs, row_edit_conditions=row_edit_conditions)
display(q)

# Verify that:
# - Tooltips for columns foo and bar are visible
# - Index column (baz) values are not bolded
# - Column bar is not editable
# - Column foo is editable
# - Row (index 42) is only editable until the value of foo is set to 'hello'

# A note on precedence of edit controls:
# - Toggle editable won't have an effect on columns or rows that have already had edits disabled via the column definitions or row edit conditions
# - Toggle editable also won't impact the ability to use the internal update methods (add_row_internally(), set_value_internally()) and only applies to manual edits

# Toggle editable -- running this once will disable edits to the grid, and running it again should reenable edits to the grid
q.send({'type': 'toggle_editable'})

# Add row internally
new_row = [
    ('baz', 43),
    ('bar', "new bar"),
    ('boo', 58), 
    ('foo', "new foo")
]
q.add_row_internally(new_row)

# Set value internally
q.set_value_internally(42, 'foo', 'hello')
```

This will be my first PR against an existing open-source project that I didn't create from scratch on my own, so please let me know if there are any glaring issues that need to be fixed before merging.  I'm very interested in any feedback you may have and would be happy to make tweaks or to discuss improvements.  Also, I have included unit tests for the internal update methods described above, but am a little stumped on how to write tests for the front-end parts that can only be observed through interaction.  If anyone has any suggestions I will happily write more tests to cover those things as well.

Thanks for reading!
