### PR TITLE
Use editable_row_callback to determine if row should be editable

### DIFF
--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -517,6 +517,11 @@ class QgridView extends widgets.DOMWidgetView {
               result = true;
             }
             result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
+        } else if (op == 'NOR') {
+            if (result == null) {
+              result = false;
+            }
+            result = result || !evaluateRowEditConditions(current_row, {'OR': obj[op]});
         } else {
           alert("Unsupported operation '" + op + "' found in row edit conditions!")
         }

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -204,7 +204,6 @@ class QgridView extends widgets.DOMWidgetView {
     this.data_view = this.create_data_view(df_json.data);
     this.grid_options = this.model.get('grid_options');
     this.column_definitions = this.model.get('column_definitions');
-    this.row_edit_conditions = this.model.get('row_edit_conditions');
     this.index_col_name = this.model.get("_index_col_name");
 
     this.columns = [];
@@ -483,58 +482,12 @@ class QgridView extends widgets.DOMWidgetView {
     });
 
     // set up callbacks
-
-    // evaluate conditions under which cells in a row should be disabled (contingent on values of other cells in the same row)
-    var evaluateRowEditConditions = function(current_row, obj) {
-      var result;
-
-      for (var op in obj) {
-        if (op == 'AND') {
-            if (result == null) {
-              result = true;
-            }
-            for (var cond in obj[op]) {
-              if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
-                result = result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
-              } else {
-                result = result && (current_row[cond] == obj[op][cond]);
-              }
-            }
-        } else if (op == 'OR') {
-          if (result == null) {
-            result = false;
-          }
-          var or_result = false;
-          for (var cond in obj[op]) {
-              if (cond == 'AND' || cond == 'OR' || cond == 'NAND' || cond == 'NOR') {
-                result = result || evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
-              } else {
-                result = result || (current_row[cond] == obj[op][cond]);
-              }
-            }
-        } else if (op == 'NAND') {
-            if (result == null) {
-              result = true;
-            }
-            result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
-        } else if (op == 'NOR') {
-            if (result == null) {
-              result = false;
-            }
-            result = result || !evaluateRowEditConditions(current_row, {'OR': obj[op]});
-        } else {
-          alert("Unsupported operation '" + op + "' found in row edit conditions!")
-        }
-      }
-      return result;
-    }
-
-    if ( ! (this.row_edit_conditions == null)) {
-        var conditions = this.row_edit_conditions;
-        var grid = this.slick_grid;
-        this.slick_grid.onBeforeEditCell.subscribe(function(e, args) {
-            return evaluateRowEditConditions(grid.getDataItem(args.row), conditions);
-        });
+    let editable_rows = this.model.get('_editable_rows');
+    if (editable_rows && Object.keys(editable_rows).length > 0) {
+      this.slick_grid.onBeforeEditCell.subscribe((e, args) => {
+        editable_rows = this.model.get('_editable_rows');
+        return editable_rows[args.item[this.index_col_name]]
+      });
     }
 
     this.slick_grid.onCellChange.subscribe((e, args) => {

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -484,7 +484,7 @@ class QgridView extends widgets.DOMWidgetView {
 
     // set up callbacks
 
-    // evaluate conditions under which cells should be disabled -- this occurs on a per-row basis, i.e.,
+    // evaluate conditions under which cells in a row should be disabled (contingent on values of other cells in the same row)
     var evaluateRowEditConditions = function(current_row, obj) {
       var result;
 
@@ -493,36 +493,39 @@ class QgridView extends widgets.DOMWidgetView {
             if (result == null) {
               result = true;
             }
-            var and_result = true;
+            //var and_result = true;
             for (var cond in obj[op]) {
               if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
-                and_result = and_result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+                result = result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
               } else {
-                and_result = and_result && (current_row[cond] == obj[op][cond]);
+                result = result && (current_row[cond] == obj[op][cond]);
               }
             }
-            result = result && and_result;
         } else if (op == 'OR') {
           if (result == null) {
             result = false;
           }
           var or_result = false;
           for (var cond in obj[op]) {
-              if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
-                or_result = or_result || evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+              if (cond == 'AND' || cond == 'OR' || cond == 'NAND' || cond == 'NOR') {
+                result = result || evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
               } else {
-                or_result = or_result || (current_row[cond] == obj[op][cond]);
+                result = result || (current_row[cond] == obj[op][cond]);
               }
             }
-            result = result || or_result;
-
-        } else if (op == 'NOT') {
+        } else if (op == 'NAND') {
             if (result == null) {
               result = true;
             }
             result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
+        } else if (op == 'NOR') {
+            if (result == null) {
+              result = true;
+            }
+            result = result && !evaluateRowEditConditions(current_row, {'OR': obj[op]});
+
         } else {
-          alert("Unsupported operation '" + op + "' found in cell edit conditions!")
+          alert("Unsupported operation '" + op + "' found in row edit conditions!")
         }
       }
       return result;

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -354,7 +354,7 @@ class QgridView extends widgets.DOMWidgetView {
         continue;
       }
 
-      if ( ! (cur_column.editable) ) {
+      if (cur_column.editable == false) {
         slick_column.editor = null;
       }
 

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -493,7 +493,6 @@ class QgridView extends widgets.DOMWidgetView {
             if (result == null) {
               result = true;
             }
-            //var and_result = true;
             for (var cond in obj[op]) {
               if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
                 result = result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
@@ -518,12 +517,6 @@ class QgridView extends widgets.DOMWidgetView {
               result = true;
             }
             result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
-        } else if (op == 'NOR') {
-            if (result == null) {
-              result = true;
-            }
-            result = result && !evaluateRowEditConditions(current_row, {'OR': obj[op]});
-
         } else {
           alert("Unsupported operation '" + op + "' found in row edit conditions!")
         }
@@ -741,6 +734,12 @@ class QgridView extends widgets.DOMWidgetView {
           'type': 'selection_change'
         });
       }, 100);
+    } else if (msg.type == 'toggle_editable') {
+        if (this.slick_grid.getOptions().editable == false) {
+          this.slick_grid.setOptions({'editable': true});
+        } else {
+          this.slick_grid.setOptions({'editable': false});
+        }
     } else if (msg.col_info) {
       var filter = this.filters[msg.col_info.name];
       filter.handle_msg(msg);

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -203,6 +203,8 @@ class QgridView extends widgets.DOMWidgetView {
     var columns = this.model.get('_columns');
     this.data_view = this.create_data_view(df_json.data);
     this.grid_options = this.model.get('grid_options');
+    this.column_definitions = this.model.get('column_definitions');
+    this.row_edit_conditions = this.model.get('row_edit_conditions');
     this.index_col_name = this.model.get("_index_col_name");
 
     this.columns = [];
@@ -321,7 +323,8 @@ class QgridView extends widgets.DOMWidgetView {
         id: cur_column.name,
         sortable: false,
         resizable: true,
-        cssClass: cur_column.type
+        cssClass: cur_column.type,
+        toolTip: cur_column.toolTip
       };
 
       Object.assign(slick_column, type_info);
@@ -345,10 +348,17 @@ class QgridView extends widgets.DOMWidgetView {
       // don't allow editing index columns
       if (cur_column.is_index) {
         slick_column.editor = editors.IndexEditor;
-        slick_column.cssClass += ' idx-col';
+        if (this.grid_options.boldIndex) {
+            slick_column.cssClass += ' idx-col';
+        }
         this.index_columns.push(slick_column);
         continue;
       }
+
+      if ( ! (cur_column.editable) ) {
+        slick_column.editor = null;
+      }
+
       this.columns.push(slick_column);
     }
 
@@ -473,6 +483,59 @@ class QgridView extends widgets.DOMWidgetView {
     });
 
     // set up callbacks
+
+    // evaluate conditions under which cells should be disabled -- this occurs on a per-row basis, i.e.,
+    var evaluateRowEditConditions = function(current_row, obj) {
+      var result;
+
+      for (var op in obj) {
+        if (op == 'AND') {
+            if (result == null) {
+              result = true;
+            }
+            var and_result = true;
+            for (var cond in obj[op]) {
+              if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
+                and_result = and_result && evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+              } else {
+                and_result = and_result && (current_row[cond] == obj[op][cond]);
+              }
+            }
+            result = result && and_result;
+        } else if (op == 'OR') {
+          if (result == null) {
+            result = false;
+          }
+          var or_result = false;
+          for (var cond in obj[op]) {
+              if (cond == 'AND' || cond == 'OR' || cond == 'NOT') {
+                or_result = or_result || evaluateRowEditConditions(current_row, {[cond]: obj[op][cond]});
+              } else {
+                or_result = or_result || (current_row[cond] == obj[op][cond]);
+              }
+            }
+            result = result || or_result;
+
+        } else if (op == 'NOT') {
+            if (result == null) {
+              result = true;
+            }
+            result = result && !evaluateRowEditConditions(current_row, {'AND': obj[op]});
+        } else {
+          alert("Unsupported operation '" + op + "' found in cell edit conditions!")
+        }
+      }
+      return result;
+    }
+
+    if ( ! (this.row_edit_conditions == null)) {
+        var conditions = this.row_edit_conditions;
+        var grid = this.slick_grid;
+        this.slick_grid.onBeforeEditCell.subscribe(function(e, args) {
+            return evaluateRowEditConditions(grid.getDataItem(args.row), conditions);
+        });
+    }
+
     this.slick_grid.onCellChange.subscribe((e, args) => {
       var column = this.columns[args.cell].name;
       var data_item = this.slick_grid.getDataItem(args.row);

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -38,7 +38,12 @@ class _DefaultSettings(object):
             'sortable': True,
             'filterable': True,
             'highlightSelectedCell': False,
-            'highlightSelectedRow': True
+            'highlightSelectedRow': True,
+            'boldIndex': True
+        }
+        self._column_options = {
+            'editable': True,
+            'toolTip': "",
         }
         self._show_toolbar = False
         self._precision = None  # Defer to pandas.get_option
@@ -47,13 +52,15 @@ class _DefaultSettings(object):
         self._grid_options[optname] = optvalue
 
     def set_defaults(self, show_toolbar=None, precision=None,
-                     grid_options=None):
+                     grid_options=None, column_options=None):
         if show_toolbar is not None:
             self._show_toolbar = show_toolbar
         if precision is not None:
             self._precision = precision
         if grid_options is not None:
             self._grid_options = grid_options
+        if column_options is not None:
+            self._column_options = column_options
 
     @property
     def show_toolbar(self):
@@ -67,11 +74,15 @@ class _DefaultSettings(object):
     def precision(self):
         return self._precision or pd.get_option('display.precision') - 1
 
+    @property
+    def column_options(self):
+        return self._column_options
+
 
 defaults = _DefaultSettings()
 
 
-def set_defaults(show_toolbar=None, precision=None, grid_options=None):
+def set_defaults(show_toolbar=None, precision=None, grid_options=None, column_options=None):
     """
     Set the default qgrid options.  The options that you can set here are the
     same ones that you can pass into ``QgridWidget`` constructor, with the
@@ -94,7 +105,7 @@ def set_defaults(show_toolbar=None, precision=None, grid_options=None):
         The widget whose default behavior is changed by ``set_defaults``.
     """
     defaults.set_defaults(show_toolbar=show_toolbar, precision=precision,
-                          grid_options=grid_options)
+                          grid_options=grid_options, column_options=column_options)
 
 
 def set_grid_option(optname, optvalue):
@@ -166,7 +177,9 @@ def disable():
 
 
 def show_grid(data_frame, show_toolbar=None,
-              precision=None, grid_options=None):
+              precision=None, grid_options=None,
+              column_options=None, column_definitions=None,
+              row_edit_conditions=None):
     """
     Renders a DataFrame or Series as an interactive qgrid, represented by
     an instance of the ``QgridWidget`` class.  The ``QgridWidget`` instance
@@ -196,6 +209,12 @@ def show_grid(data_frame, show_toolbar=None,
         precision = defaults.precision
     if not isinstance(precision, Integral):
         raise TypeError("precision must be int, not %s" % type(precision))
+    if column_options is None:
+        column_options = defaults.column_options
+    else:
+        options = defaults.column_options.copy()
+        options.update(column_options)
+        column_options = options
     if grid_options is None:
         grid_options = defaults.grid_options
     else:
@@ -218,6 +237,9 @@ def show_grid(data_frame, show_toolbar=None,
     # create a visualization for the dataframe
     return QgridWidget(df=data_frame, precision=precision,
                        grid_options=grid_options,
+                       column_options=column_options,
+                       column_definitions=column_definitions,
+                       row_edit_conditions=row_edit_conditions,
                        show_toolbar=show_toolbar)
 
 
@@ -364,6 +386,9 @@ class QgridWidget(widgets.DOMWidget):
     df = Instance(pd.DataFrame)
     precision = Integer(6, sync=True)
     grid_options = Dict(sync=True)
+    column_options = Dict(sync=True)
+    column_definitions = Dict({})
+    row_edit_conditions = Dict(sync=True)
     show_toolbar = Bool(False, sync=True)
 
     def __init__(self, *args, **kwargs):
@@ -506,6 +531,10 @@ class QgridWidget(widgets.DOMWidget):
 
                 cur_column['position'] = i
                 columns[col_name] = cur_column
+
+                columns[col_name].update(self.column_options)
+                if col_name in self.column_definitions.keys():
+                    columns[col_name].update(self.column_definitions[col_name])
 
             self._columns = columns
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1064,6 +1064,39 @@ class QgridWidget(widgets.DOMWidget):
                            scroll_to_row=df.index.get_loc(last.name))
         self._trigger_df_change_event()
 
+    def add_row_internally(self, row):
+        """
+        Append a new row to the end of the dataframe given a list of 2-tuples of (column name, column value).
+        This feature will work for dataframes with arbitrary index types.
+        """
+        df = self._df
+
+        col_names, col_data = zip(*row)
+        col_names = list(col_names)
+        col_data = list(col_data)
+        index_col_val = dict(row)[df.index.name]
+
+        # check that the given column names match what already exists in the dataframe
+        required_cols = set(df.columns.values).union({df.index.name}) - {self._index_col_name}
+        if set(col_names) != required_cols:
+            msg = "Cannot add row -- column names don't match in the existing dataframe"
+            self.send({
+                'type': 'show_error',
+                'error_msg': msg,
+                'triggered_by': 'add_row'
+            })
+            return
+
+        for i, s in enumerate(col_data):
+            if col_names[i] == df.index.name:
+                continue
+
+            df.loc[index_col_val, col_names[i]] = s
+            self._unfiltered_df.loc[index_col_val, col_names[i]] = s
+
+        self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val))
+        self._trigger_df_change_event()
+
     def remove_row(self):
         """
         Remove the current row from the table.

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import json
 
+from types import FunctionType
 from IPython.display import display
 from numbers import Integral
 from traitlets import Unicode, Instance, Bool, Integer, Dict, List, Tuple, Any
@@ -179,7 +180,7 @@ def disable():
 def show_grid(data_frame, show_toolbar=None,
               precision=None, grid_options=None,
               column_options=None, column_definitions=None,
-              row_edit_conditions=None):
+              row_edit_callback=None):
     """
     Renders a DataFrame or Series as an interactive qgrid, represented by
     an instance of the ``QgridWidget`` class.  The ``QgridWidget`` instance
@@ -234,7 +235,6 @@ def show_grid(data_frame, show_toolbar=None,
             "data_frame must be DataFrame or Series, not %s" % type(data_frame)
         )
 
-    row_edit_conditions = (row_edit_conditions or {})
     column_definitions = (column_definitions or {})
 
     # create a visualization for the dataframe
@@ -242,7 +242,7 @@ def show_grid(data_frame, show_toolbar=None,
                        grid_options=grid_options,
                        column_options=column_options,
                        column_definitions=column_definitions,
-                       row_edit_conditions=row_edit_conditions,
+                       row_edit_callback=row_edit_callback,
                        show_toolbar=show_toolbar)
 
 
@@ -366,6 +366,7 @@ class QgridWidget(widgets.DOMWidget):
     _df_json = Unicode('', sync=True)
     _primary_key = List()
     _columns = Dict({}, sync=True)
+    _editable_rows = Dict({}, sync=True)
     _filter_tables = Dict({})
     _sorted_column_cache = Dict({})
     _interval_columns = List([], sync=True)
@@ -391,7 +392,7 @@ class QgridWidget(widgets.DOMWidget):
     grid_options = Dict(sync=True)
     column_options = Dict(sync=True)
     column_definitions = Dict({})
-    row_edit_conditions = Dict(sync=True)
+    row_edit_callback = Instance(FunctionType, sync=False, allow_none=True)
     show_toolbar = Bool(False, sync=True)
 
     def __init__(self, *args, **kwargs):
@@ -573,6 +574,13 @@ class QgridWidget(widgets.DOMWidget):
                                       double_precision=self.precision)
 
         self._df_json = df_json
+
+        if self.row_edit_callback is not None:
+            editable_rows = {}
+            for index, row in df.iterrows():
+                editable_rows[int(row[self._index_col_name])] = self.row_edit_callback(row)
+            self._editable_rows = editable_rows
+
         if fire_data_change_event:
             data_to_send = {
                 'type': 'update_data_view',

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1100,6 +1100,12 @@ class QgridWidget(widgets.DOMWidget):
         self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val), fire_data_change_event=True)
         self._trigger_df_change_event()
 
+    def set_value_internally(self, index, column, value):
+        self._df.loc[index, column] = value
+        self._unfiltered_df.loc[index, column] = value
+        self._update_table(triggered_by='cell_change', fire_data_change_event=True)
+        self._trigger_df_change_event()
+
     def remove_row(self):
         """
         Remove the current row from the table.

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -234,6 +234,9 @@ def show_grid(data_frame, show_toolbar=None,
             "data_frame must be DataFrame or Series, not %s" % type(data_frame)
         )
 
+    row_edit_conditions = (row_edit_conditions or {})
+    column_definitions = (column_definitions or {})
+
     # create a visualization for the dataframe
     return QgridWidget(df=data_frame, precision=precision,
                        grid_options=grid_options,
@@ -1094,7 +1097,7 @@ class QgridWidget(widgets.DOMWidget):
             df.loc[index_col_val, col_names[i]] = s
             self._unfiltered_df.loc[index_col_val, col_names[i]] = s
 
-        self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val))
+        self._update_table(triggered_by='add_row', scroll_to_row=df.index.get_loc(index_col_val), fire_data_change_event=True)
         self._trigger_df_change_event()
 
     def remove_row(self):

--- a/qgrid/tests/test_grid.py
+++ b/qgrid/tests/test_grid.py
@@ -131,6 +131,29 @@ def test_nans():
         'search_val': None
     })
 
+def test_row_edit_callback():
+    sample_df = create_df()
+
+    def can_edit_row(row):
+        return row['E'] == 'train' and row['F'] == 'bar'
+
+    view = QgridWidget(df=sample_df, row_edit_callback=can_edit_row)
+
+    view._handle_qgrid_msg_helper({
+        'type': 'sort_changed',
+        'sort_field': 'index',
+        'sort_ascending': True
+    })
+
+    expected_dict = {
+        0: False,
+        1: True,
+        2: False,
+        3: False
+    }
+
+    assert expected_dict == view._editable_rows
+
 def test_period_object_column():
     range_index = pd.period_range(start='2000', periods=10, freq='B')
     df = pd.DataFrame({'a': 5, 'b': range_index}, index=range_index)

--- a/qgrid/tests/test_grid.py
+++ b/qgrid/tests/test_grid.py
@@ -409,3 +409,33 @@ def test_object_dtype_categorical():
     })
     assert len(widget._df) == 1
     assert widget._df[0][0] == cat_series[0]
+
+
+def test_add_row_internally():
+    df = pd.DataFrame({'foo': ['hello'], 'bar': ['world'], 'baz': [42], 'boo': [57]})
+    df.set_index('baz', inplace=True, drop=True)
+
+    q = QgridWidget(df=df)
+
+    new_row = [
+        ('baz', 43),
+        ('bar', "new bar"),
+        ('boo', 58),
+        ('foo', "new foo")
+    ]
+
+    q.add_row_internally(new_row)
+
+    assert q._df.loc[43, 'foo'] == 'new foo'
+    assert q._df.loc[42, 'foo'] == 'hello'
+
+
+def test_set_value_internally():
+    df = pd.DataFrame({'foo': ['hello'], 'bar': ['world'], 'baz': [42], 'boo': [57]})
+    df.set_index('baz', inplace=True, drop=True)
+
+    q = QgridWidget(df=df)
+
+    q.set_value_internally(42, 'foo', 'hola')
+
+    assert q._df.loc[42, 'foo'] == 'hola'


### PR DESCRIPTION
This is a branch off of the following PR: https://github.com/quantopian/qgrid/pull/191

My reasoning for using a callback function is it's more flexible/powerful and fewer lines of code for us to maintain.  

Also I'm thinking ahead to other similar feature which we'll want, like have the ability to highlight rows/cells with a background color based on the contents of the rows.  For those cases we'll definitely want the ability to do stuff like highlight all rows where an integers is less than zero. With a callback function we can handle that type of comparison, because we'll have the full power of python available to us in the callback, rather than being limited to a subset that we've added support for in the row_edit_conditions grammar.

There's one other small tweak here which is to make it so that columns default to being editable if the editable attribute is not specified when constructing the `QgridWidget`.  This is only an issue when constructing `QgridWidget` directly so you wouldn't have noticed it if you've just been testing with `show_grid`.