### PR TITLE
Include LICENSE file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Although not strictly required by the license, having a copy of the license file is preferred by some groups such as Linux distros that repackage the software.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.