### PR TITLE
Add 'toggle_editable' method, and fix the 'boldIndex' grid option

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qgrid",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "description": "An Interactive Grid for Sorting and Filtering DataFrames in Jupyter Notebook",
   "author": "Quantopian Inc.",
   "main": "src/index.js",

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -681,7 +681,7 @@ class QgridView extends widgets.DOMWidgetView {
           this.buttons.tooltip('disable');
         }
       }
-      if (this.update_timeout){
+      if (this.update_timeout) {
         clearTimeout(this.update_timeout);
       }
       this.update_timeout = setTimeout(() => {
@@ -690,7 +690,7 @@ class QgridView extends widgets.DOMWidgetView {
         this.multi_index = this.model.get("_multi_index");
         var data_view = this.create_data_view(df_json.data);
 
-        if (msg.triggered_by === 'change_viewport'){
+        if (msg.triggered_by === 'change_viewport') {
           if (this.next_viewport_msg) {
             this.send(this.next_viewport_msg);
             this.next_viewport_msg = null;
@@ -700,7 +700,7 @@ class QgridView extends widgets.DOMWidgetView {
           }
         }
 
-        if (msg.triggered_by == 'change_sort' && this.sort_indicator){
+        if (msg.triggered_by == 'change_sort' && this.sort_indicator) {
           var asc = this.model.get('_sort_ascending');
           this.sort_indicator.removeClass(
               'fa-spinner fa-spin fa-sort-asc fa-sort-desc'
@@ -711,7 +711,7 @@ class QgridView extends widgets.DOMWidgetView {
         }
 
         let top_row = null;
-        if (msg.triggered_by === 'remove_row'){
+        if (msg.triggered_by === 'remove_row') {
           top_row = this.slick_grid.getViewport().top;
         }
 
@@ -719,7 +719,7 @@ class QgridView extends widgets.DOMWidgetView {
 
         var skip_grouping = false;
         if (this.multi_index) {
-          for (var i=1; i < this.filter_list.length; i++) {
+          for (var i = 1; i < this.filter_list.length; i++) {
             var cur_filter = this.filter_list[i];
             if (cur_filter.is_active()) {
               skip_grouping = true;
@@ -736,7 +736,7 @@ class QgridView extends widgets.DOMWidgetView {
         this.slick_grid.render();
 
         if ((msg.triggered_by == 'add_row' ||
-          msg.triggered_by == 'remove_row') && !this.has_active_filter()) {
+            msg.triggered_by == 'remove_row') && !this.has_active_filter()) {
           this.update_size();
         }
         this.update_timeout = null;
@@ -767,12 +767,12 @@ class QgridView extends widgets.DOMWidgetView {
         this.slick_grid.resizeCanvas();
       }
     } else if (msg.type == 'change_selection') {
-        this.ignore_selection_changed = true;
-        this.slick_grid.setSelectedRows(msg.rows);
-        if (msg.rows && msg.rows.length > 0) {
-          this.slick_grid.scrollRowIntoView(msg.rows[0]);
-        }
-        this.ignore_selection_changed = false;
+      this.ignore_selection_changed = true;
+      this.slick_grid.setSelectedRows(msg.rows);
+      if (msg.rows && msg.rows.length > 0) {
+        this.slick_grid.scrollRowIntoView(msg.rows[0]);
+      }
+      this.ignore_selection_changed = false;
     } else if (msg.col_info) {
       var filter = this.filters[msg.col_info.name];
       filter.handle_msg(msg);

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -760,12 +760,13 @@ class QgridView extends widgets.DOMWidgetView {
           'type': 'change_selection'
         });
       }, 100);
-    } else if (msg.type == 'toggle_editable') {
-        if (this.slick_grid.getOptions().editable == false) {
-          this.slick_grid.setOptions({'editable': true});
-        } else {
-          this.slick_grid.setOptions({'editable': false});
-        }
+    } else if (msg.type == 'change_grid_option') {
+      var opt_name = msg.option_name;
+      var opt_val = msg.option_value;
+      if (this.slick_grid.getOptions()[opt_name] != opt_val) {
+        this.slick_grid.setOptions({[opt_name]: opt_val});
+        this.slick_grid.resizeCanvas();
+      }
     } else if (msg.type == 'change_selection') {
         this.ignore_selection_changed = true;
         this.slick_grid.setSelectedRows(msg.rows);

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -352,8 +352,7 @@ class QgridView extends widgets.DOMWidgetView {
       // don't allow editing index columns
       if (cur_column.is_index) {
         slick_column.editor = editors.IndexEditor;
-
-        slick_column.cssClass += ' idx-col';
+        
         if (cur_column.first_index){
           slick_column.cssClass += ' first-idx-col';
         }

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -36,8 +36,8 @@ class QgridModel extends widgets.DOMWidgetModel {
       _view_name : 'QgridView',
       _model_module : 'qgrid',
       _view_module : 'qgrid',
-      _model_module_version : '^1.1.0-beta.0',
-      _view_module_version : '^1.1.0-beta.0',
+      _model_module_version : '^1.1.0-beta.1',
+      _view_module_version : '^1.1.0-beta.1',
       _df_json: '',
       _columns: {}
     });

--- a/qgrid/_version.py
+++ b/qgrid/_version.py
@@ -1,4 +1,4 @@
-version_info = (1, 1, 0, 'beta', 0)
+version_info = (1, 1, 0, 'beta', 1)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1796,5 +1796,32 @@ class QgridWidget(widgets.DOMWidget):
             'source': source
         })
 
+    def toggle_editable(self):
+        """
+        Change whether the grid is editable or not, without rebuilding
+        the entire grid widget.
+        """
+        self.change_grid_option('editable', not self.grid_options['editable'])
+
+    def change_grid_option(self, option_name, option_value):
+        """
+        Change a SlickGrid grid option without rebuilding the entire grid
+        widget.
+
+        Parameters
+        ----------
+        option_name : str
+            The name of the grid option to be changed.
+        option_value : str
+            The new value for the grid option.
+        """
+        self.grid_options[option_name] = option_value
+        self.send({
+            'type': 'change_grid_option',
+            'option_name': option_name,
+            'option_value': option_value
+        })
+
+
 # Alias for legacy support, since we changed the capitalization
 QGridWidget = QgridWidget

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -566,8 +566,8 @@ class QgridWidget(widgets.DOMWidget):
     _model_name = Unicode('QgridModel').tag(sync=True)
     _view_module = Unicode('qgrid').tag(sync=True)
     _model_module = Unicode('qgrid').tag(sync=True)
-    _view_module_version = Unicode('1.1.0-beta.0').tag(sync=True)
-    _model_module_version = Unicode('1.1.0-beta.0').tag(sync=True)
+    _view_module_version = Unicode('1.1.0-beta.1').tag(sync=True)
+    _model_module_version = Unicode('1.1.0-beta.1').tag(sync=True)
 
     _df = Instance(pd.DataFrame)
     _df_json = Unicode('', sync=True)

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1806,7 +1806,8 @@ class QgridWidget(widgets.DOMWidget):
     def change_grid_option(self, option_name, option_value):
         """
         Change a SlickGrid grid option without rebuilding the entire grid
-        widget.
+        widget. Not all options are supported at this point so this
+        method should be considered experimental.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixing a couple of features that I had forgotten to test before merging https://github.com/quantopian/qgrid/pull/195

Adds `toggle_editable` and `change_grid_option` methods.  The former should work consistently but the latter should be considered experimental, as it doesn't work well with all options.

Fixes the `boldIndex` grid option, which got broken when I rebased the referenced PR against master.

Bumping to 1.1.0-beta.1