### PR TITLE
Add doc string for the edit_cell method

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qgrid",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An Interactive Grid for Sorting and Filtering DataFrames in Jupyter Notebook",
   "author": "Quantopian Inc.",
   "main": "src/index.js",

--- a/js/src/qgrid.css
+++ b/js/src/qgrid.css
@@ -155,6 +155,14 @@
   height: 315px !important;
 }
 
+.q-grid-toolbar {
+  display: none;
+}
+
+.show-toolbar .q-grid-toolbar {
+  display: block;
+}
+
 .output_scroll .show-toolbar .q-grid {
   height: 284px !important;
 }

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -62,16 +62,21 @@ class QgridView extends widgets.DOMWidgetView {
     if (!this.$el.hasClass('q-grid-container')){
       this.$el.addClass('q-grid-container');
     }
-
-    if (this.model.get('show_toolbar')) {
-      this.initialize_toolbar();
-    }
-
+    this.initialize_toolbar();
     this.initialize_slick_grid();
   }
 
   initialize_toolbar() {
-    this.$el.addClass('show-toolbar');
+    if (!this.model.get('show_toolbar')){
+      this.$el.removeClass('show-toolbar');
+    } else {
+      this.$el.addClass('show-toolbar');
+    }
+
+    if (this.toolbar){
+      return;
+    }
+
     this.toolbar = $("<div class='q-grid-toolbar'>").appendTo(this.$el);
 
     let append_btn = (btn_info) => {
@@ -196,7 +201,10 @@ class QgridView extends widgets.DOMWidgetView {
    * type of data in the columns of the DataFrame provided by the user.
    */
   initialize_slick_grid() {
-    this.grid_elem = $("<div class='q-grid'>").appendTo(this.$el);
+
+    if (!this.grid_elem) {
+      this.grid_elem = $("<div class='q-grid'>").appendTo(this.$el);
+    }
 
     // create the table
     var df_json = JSON.parse(this.model.get('_df_json'));
@@ -414,6 +422,8 @@ class QgridView extends widgets.DOMWidgetView {
     this.slick_grid.setSelectionModel(new Slick.RowSelectionModel());
     this.slick_grid.setCellCssStyles("grouping", this.row_styles);
     this.slick_grid.render();
+    
+    this.update_size();
 
     var render_header_cell = (e, args) => {
       var cur_filter = this.filters[args.column.id];
@@ -664,7 +674,7 @@ class QgridView extends widgets.DOMWidgetView {
    */
   handle_msg(msg) {
     if (msg.type === 'draw_table') {
-      this.initialize_qgrid();
+      this.initialize_slick_grid();
     } else if (msg.type == 'show_error') {
       alert(msg.error_msg);
       if (msg.triggered_by == 'add_row' ||
@@ -773,6 +783,8 @@ class QgridView extends widgets.DOMWidgetView {
         this.slick_grid.scrollRowIntoView(msg.rows[0]);
       }
       this.ignore_selection_changed = false;
+    } else if (msg.type == 'change_show_toolbar') {
+      this.initialize_toolbar();
     } else if (msg.col_info) {
       var filter = this.filters[msg.col_info.name];
       filter.handle_msg(msg);

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -399,6 +399,7 @@ class QgridView extends widgets.DOMWidgetView {
       this.columns,
       this.grid_options
     );
+    this.grid_elem.data('slickgrid', this.slick_grid);
 
     if (this.grid_options.forceFitColumns){
       this.grid_elem.addClass('force-fit-columns');

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -36,8 +36,8 @@ class QgridModel extends widgets.DOMWidgetModel {
       _view_name : 'QgridView',
       _model_module : 'qgrid',
       _view_module : 'qgrid',
-      _model_module_version : '^1.1.0',
-      _view_module_version : '^1.1.0',
+      _model_module_version : '^1.1.1',
+      _view_module_version : '^1.1.1',
       _df_json: '',
       _columns: {}
     });

--- a/qgrid/_version.py
+++ b/qgrid/_version.py
@@ -1,4 +1,4 @@
-version_info = (1, 1, 0, 'final')
+version_info = (1, 1, 1, 'final')
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -843,7 +843,7 @@ class QgridWidget(widgets.DOMWidget):
     def _show_toolbar_changed(self):
         if not self._initialized:
             return
-        self._rebuild_widget()
+        self.send({'type': 'change_show_toolbar'})
 
     def _update_table(self,
                       update_columns=False,

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -566,8 +566,8 @@ class QgridWidget(widgets.DOMWidget):
     _model_name = Unicode('QgridModel').tag(sync=True)
     _view_module = Unicode('qgrid').tag(sync=True)
     _model_module = Unicode('qgrid').tag(sync=True)
-    _view_module_version = Unicode('1.1.0').tag(sync=True)
-    _model_module_version = Unicode('1.1.0').tag(sync=True)
+    _view_module_version = Unicode('1.1.1').tag(sync=True)
+    _model_module_version = Unicode('1.1.1').tag(sync=True)
 
     _df = Instance(pd.DataFrame)
     _df_json = Unicode('', sync=True)

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1689,6 +1689,20 @@ class QgridWidget(widgets.DOMWidget):
         return index_col_val
 
     def edit_cell(self, index, column, value):
+        """
+        Edit a cell of the grid, given the index and column of the cell
+        to edit, as well as the new value of the cell. Results in a
+        ``cell_edited`` event being fired.
+
+        Parameters
+        ----------
+        index : object
+            The index of the row containing the cell that is to be edited.
+        column : str
+            The name of the column containing the cell that is to be edited.
+        value : object
+            The new value for the cell.
+        """
         old_value = self._df.loc[index, column]
         self._df.loc[index, column] = value
         self._unfiltered_df.loc[index, column] = value


### PR DESCRIPTION
Some other small fixes for pre-existing issues:

- Fixes issue where the grid widget would noticeably flash when the dataframe was swapped out via the df property (#186)
- Make SlickGrid object available via `$('.q-grid').data('slickgrid')` as suggested here: https://github.com/quantopian/qgrid/issues/178#issuecomment-371420892

