### PR TITLE
fixed pop exception

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -306,7 +306,7 @@ def enable(dataframe=True, series=True):
     if series:
         ip_formatter.for_type(pd.Series, _display_as_qgrid)
     else:
-        ip_formatter.type_printers.pop(pd.Series)
+        ip_formatter.type_printers.pop(pd.Series, None)
 
 
 def disable():


### PR DESCRIPTION
bug fix: 
multiple consecutive calls on qgrid.disable() trigger a pop exception.

side note:
qgrid.disable() might interfere with other dataframe printers. 
For now just fixed the exeption