### PR TITLE
Implementation of basic context menu

### DIFF
--- a/js/src/qgrid.css
+++ b/js/src/qgrid.css
@@ -429,6 +429,28 @@
   border-left: 1px solid #cccccc;
 }
 
+/* Context menu */
+
+.q-grid-container #contextMenu {
+  background: rgb(245, 245, 245);
+  border: 1px solid gray;
+  padding: 2px;
+  display: inline-block;
+  min-width: 100px;
+  -moz-box-shadow: 2px 2px 2px silver;
+  -webkit-box-shadow: 2px 2px 2px silver;
+  z-index: 99999;
+}
+
+.q-grid-container #contextMenu li {
+  padding: 4px 4px 4px 14px;
+  list-style: none;
+}
+
+.q-grid-container #contextMenu li:hover {
+  background-color: #cccccc;
+}
+
 /* Filter dropdowns */
 
 .q-grid-container .grid-filter {

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -401,6 +401,33 @@ class QgridView extends widgets.DOMWidgetView {
     );
     this.grid_elem.data('slickgrid', this.slick_grid);
 
+    if (this.grid_options.context_menu){
+      if (!this.context_elem) {
+        this.context_elem = $(`<ul id='contextMenu' style='display:none;position:absolute'</ul>`).appendTo(this.$el);
+        this.grid_options.context_menu.forEach(o => {$(`<li>${o}</li>`).appendTo(this.context_elem)});
+      }
+    }
+    
+    this.slick_grid.onContextMenu.subscribe((e) => {
+      
+      //calculate x,y position for the context menu
+      e.preventDefault();
+      var bounds = this.$el[0].getBoundingClientRect();
+      var x = e.pageX - bounds.left;
+      var y = e.pageY - bounds.top;
+
+      var cell = this.slick_grid.getCellFromEvent(e);
+
+      this.context_elem
+          .data("cell", cell)
+          .css("top", y)
+          .css("left", x)
+          .show();
+      $("body").one("click", () => {
+        this.context_elem.hide();
+      });
+    });
+
     if (this.grid_options.forceFitColumns){
       this.grid_elem.addClass('force-fit-columns');
     }

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -402,31 +402,23 @@ class QgridView extends widgets.DOMWidgetView {
     this.grid_elem.data('slickgrid', this.slick_grid);
 
     if (this.grid_options.context_menu){
-      if (!this.context_elem) {
-        this.context_elem = $(`<ul id='contextMenu' style='display:none;position:absolute'</ul>`).appendTo(this.$el);
-        this.grid_options.context_menu.forEach(o => {$(`<li>${o}</li>`).appendTo(this.context_elem)});
-      }
-    }
-    
-    this.slick_grid.onContextMenu.subscribe((e) => {
+      this.slick_grid.onContextMenu.subscribe((e) => {
       
-      //calculate x,y position for the context menu
-      e.preventDefault();
-      var bounds = this.$el[0].getBoundingClientRect();
-      var x = e.pageX - bounds.left;
-      var y = e.pageY - bounds.top;
-
-      var cell = this.slick_grid.getCellFromEvent(e);
-
-      this.context_elem
-          .data("cell", cell)
-          .css("top", y)
-          .css("left", x)
-          .show();
-      $("body").one("click", () => {
-        this.context_elem.hide();
+        //calculate x,y position for the context menu
+        e.preventDefault();
+        var bounds = this.$el[0].getBoundingClientRect();
+        var x = e.pageX - bounds.left;
+        var y = e.pageY - bounds.top;
+  
+        var cell = this.slick_grid.getCellFromEvent(e);
+        this.send({
+          type: 'show_context_menu',
+          x,
+          y,
+          cell
+        })
       });
-    });
+    }
 
     if (this.grid_options.forceFitColumns){
       this.grid_elem.addClass('force-fit-columns');
@@ -816,6 +808,8 @@ class QgridView extends widgets.DOMWidgetView {
     } else if (msg.col_info) {
       var filter = this.filters[msg.col_info.name];
       filter.handle_msg(msg);
+    } else if (msg.type == 'show_context_menu'){
+      this.show_context_menu(msg.x, msg.y, msg.cell, msg.items)
     }
   }
 
@@ -827,6 +821,23 @@ class QgridView extends widgets.DOMWidgetView {
       );
       this.in_progress_btn = null;
     }
+  }
+
+  show_context_menu (x,y,cell, items) {
+    if (!this.context_elem) {
+      this.context_elem = $(`<ul id='contextMenu' style='display:none;position:absolute'</ul>`).appendTo(this.$el);
+    }
+    this.context_elem.empty();
+    items.forEach(o => {$(`<li>${o}</li>`).appendTo(this.context_elem)});
+
+    this.context_elem
+        .data("cell", cell)
+        .css("top", y)
+        .css("left", x)
+        .show();
+    $("body").one("click", () => {
+      this.context_elem.hide();
+    });
   }
 
   /**

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -835,6 +835,17 @@ class QgridView extends widgets.DOMWidgetView {
         .css("top", y)
         .css("left", x)
         .show();
+
+    this.context_elem.find('li').one("click", e => {
+      var cell = this.context_elem.data("cell");
+      var item = $(e.target).text()
+      this.send({
+        'type': 'context_menu_item_clicked',
+        item,
+        cell
+      })
+    });
+
     $("body").one("click", () => {
       this.context_elem.hide();
     });

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -504,6 +504,8 @@ def show_grid(data_frame,
 
     if context_menu:
         grid_options['context_menu'] = True
+    else:
+        context_menu = {}
 
     if not isinstance(grid_options, dict):
         raise TypeError(
@@ -1572,13 +1574,14 @@ class QgridWidget(widgets.DOMWidget):
         elif content['type'] == 'show_context_menu':
             x, y, cell = content['x'], content['y'], content['cell']
             items = self.context_menu['items_callback'](cell)
-            self.send({
-                'type': 'show_context_menu',
-                'x': x,
-                'y': y,
-                'cell':cell,
-                'items': items
-            })
+            if items and isinstance(items, list):
+                self.send({
+                    'type': 'show_context_menu',
+                    'x': x,
+                    'y': y,
+                    'cell':cell,
+                    'items': items
+                })
         elif content['type'] == 'context_menu_item_clicked':
             cell, item = content['cell'], content['item']
             self.context_menu['click_callback'](cell, item)

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1579,6 +1579,9 @@ class QgridWidget(widgets.DOMWidget):
                 'cell':cell,
                 'items': items
             })
+        elif content['type'] == 'context_menu_item_clicked':
+            cell, item = content['cell'], content['item']
+            self.context_menu['click_callback'](cell, item)
 
     def _notify_listeners(self, event):
         # notify listeners at the module level

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -1576,6 +1576,7 @@ class QgridWidget(widgets.DOMWidget):
                 'type': 'show_context_menu',
                 'x': x,
                 'y': y,
+                'cell':cell,
                 'items': items
             })
 


### PR DESCRIPTION
Added implementation of a basic context menu, i.e. a menu that will appear when the user right-clicks on the grid. The main idea is to define two callbacks:
1- **items_callback**: which will be called when the user right-clicks on a cell, and it should return a  list of items (strings) to be shown in the context menu, based on the clicked cell. 

2- **click_callback**: which will be called when the user clicks one of the menu items. 