### PR TITLE
Allow chainable show_grid in pandas

### DIFF
--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,6 +1,6 @@
 from ._version import version_info, __version__
 
-import . import pandas_decorator
+from . import pandas_decorator
 from .grid import (
     enable,
     disable,

--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,5 +1,6 @@
 from ._version import version_info, __version__
 
+from .pandas_decorator
 from .grid import (
     enable,
     disable,
@@ -11,6 +12,7 @@ from .grid import (
     QgridWidget,
     QGridWidget
 )
+
 
 def _jupyter_nbextension_paths():
     return [{

--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,6 +1,6 @@
 from ._version import version_info, __version__
 
-import .pandas_decorator
+import . import pandas_decorator
 from .grid import (
     enable,
     disable,

--- a/qgrid/__init__.py
+++ b/qgrid/__init__.py
@@ -1,6 +1,6 @@
 from ._version import version_info, __version__
 
-from .pandas_decorator
+import .pandas_decorator
 from .grid import (
     enable,
     disable,

--- a/qgrid/pandas_decorator.py
+++ b/qgrid/pandas_decorator.py
@@ -1,0 +1,9 @@
+
+from pandas import DataFrame
+from .grid import show_grid
+
+
+def show_grid(df, **kwargs):
+   return show_grid(df, **kwargs)
+   
+DataFrame.show_grid = show_grid

--- a/qgrid/pandas_decorator.py
+++ b/qgrid/pandas_decorator.py
@@ -1,7 +1,7 @@
 from pandas import DataFrame
 from .grid import show_grid
 
-def show_grid(df, **kwargs):
+def _show_grid(df, **kwargs):
    return show_grid(df, **kwargs)
    
-DataFrame.show_grid = show_grid
+DataFrame.show_grid = _show_grid

--- a/qgrid/pandas_decorator.py
+++ b/qgrid/pandas_decorator.py
@@ -1,7 +1,5 @@
-
 from pandas import DataFrame
 from .grid import show_grid
-
 
 def show_grid(df, **kwargs):
    return show_grid(df, **kwargs)


### PR DESCRIPTION
Adding show_grid function to pandas dataframe to allow a cleaner chainable work with dataframes, for example 
df.read_csv().show_grid()