### PR TITLE
Support for JupyterLab 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,7 +216,7 @@ to do this.
 
 #. If desired, install the labextension::
 
-    jupyter labextension install js/
+    jupyter labextension link js/
 
 #. Run the notebook as you normally would with the following command::
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qgrid2",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "An Interactive Grid for Sorting and Filtering DataFrames in Jupyter Notebook",
   "author": "Quantopian Inc.",
   "main": "src/index.js",
@@ -16,27 +16,28 @@
   ],
   "scripts": {
     "clean": "rimraf dist/",
-    "prepublish": "webpack",
+    "prepare": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "jshint": "^2.9.5",
-    "rimraf": "^2.6.1",
-    "webpack": "^3.5.5"
+    "css-loader": "^3.4.2",
+    "expose-loader": "^0.7.5",
+    "file-loader": "^6.0.0",
+    "jshint": "^2.11.0",
+    "json-loader": "^0.5.7",
+    "rimraf": "^3.0.2",
+    "style-loader": "^1.1.3",
+    "webpack": "^4.42.0",
+    "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.1 || ^2",
-    "@jupyter-widgets/controls": "^1.0.0 || ^1.5.1",
-    "css-loader": "^0.28.7",
-    "expose-loader": "^0.7.3",
-    "file-loader": "^0.11.2",
+    "@jupyter-widgets/base": "^1.1 || ^2 || ^3",
+    "@jupyter-widgets/controls": "^1 || ^2",
     "jquery": "^3.2.1",
-    "jquery-ui-dist": "1.12.1",
-    "json-loader": "^0.5.4",
-    "moment": "^2.18.1",
+    "jquery-ui-dist": "^1.12.1",
+    "moment": "^2.24.0",
     "slickgrid-qgrid": "0.0.5",
-    "style-loader": "^0.18.2",
-    "underscore": "^1.8.3"
+    "underscore": "^1.9.2"
   },
   "jshintConfig": {
     "esversion": 6

--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -36,8 +36,8 @@ class QgridModel extends widgets.DOMWidgetModel {
       _view_name : 'QgridView',
       _model_module : 'qgrid',
       _view_module : 'qgrid',
-      _model_module_version : '^1.1.1',
-      _view_module_version : '^1.1.1',
+      _model_module_version : '^1.1.2',
+      _view_module_version : '^1.1.2',
       _df_json: '',
       _columns: {}
     });

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -42,7 +42,8 @@ module.exports = [
             path: path.resolve(__dirname, '..', 'qgrid', 'static'),
             libraryTarget: 'amd'
         },
-        plugins: plugins
+        plugins: plugins,
+        mode: 'production'
     },
     {// Bundle for the notebook containing the custom widget views and models
      //
@@ -61,7 +62,8 @@ module.exports = [
             rules: rules
         },
         externals: ['@jupyter-widgets/base', '@jupyter-widgets/controls', 'base/js/dialog'],
-        plugins: plugins
+        plugins: plugins,
+        mode: 'production'
     },
     {// Embeddable qgrid bundle
      //
@@ -89,6 +91,7 @@ module.exports = [
             rules: rules
         },
         externals: ['@jupyter-widgets/base', '@jupyter-widgets/controls'],
-        plugins: plugins
+        plugins: plugins,
+        mode: 'production'
     }
 ];

--- a/qgrid/_version.py
+++ b/qgrid/_version.py
@@ -1,4 +1,4 @@
-version_info = (1, 3, 0, "final")
+version_info = (1, 3, 1, "final")
 
 _specifier_ = {"alpha": "a", "beta": "b", "candidate": "rc", "final": ""}
 

--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -566,8 +566,8 @@ class QgridWidget(widgets.DOMWidget):
     _model_name = Unicode('QgridModel').tag(sync=True)
     _view_module = Unicode('qgrid').tag(sync=True)
     _model_module = Unicode('qgrid').tag(sync=True)
-    _view_module_version = Unicode('1.1.1').tag(sync=True)
-    _model_module_version = Unicode('1.1.1').tag(sync=True)
+    _view_module_version = Unicode('^1.1.3').tag(sync=True)
+    _model_module_version = Unicode('^1.1.3').tag(sync=True)
 
     _df = Instance(pd.DataFrame)
     _df_json = Unicode('', sync=True)


### PR DESCRIPTION
Fixes #299. JupyterLab 2.0.0 is out, and this jupyterlab extension have conflicting dependencies. Note that the failing CI test is related to #300 which is not associated with this PR.

## References for JupyterLab extension migration
- [Change log for developers](https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#for-developers)
- [A migration guide](https://jupyterlab.readthedocs.io/en/stable/developer/extension_migration.html#extension-migration)

## PR summary
- Dependency bumps and refactoring.
- Moved various webpack loaders from being `dependencies` to being `devDependencies`.
- Updated a development setup note in the README.
- Bumped package.json's version to 1.1.3, and setup.py's imported version to 1.3.1.

## Try PR
```
conda install jupyterlab=2
jupyter labextension update @jupyter-widgets/jupyterlab-manager

git clone https://github.com/consideratio/qgrid
cd qgrid
git checkout jlab2

pip install -e .
jlpm install --cwd ./js # like npm install ./js but with guaranteed to use jupyterlab's node
jupyter labextension link ./js

jupyter lab

# code in a cell
import qgrid
import pandas as pd
df = pd.DataFrame({'X':[78,85,96,80,86], 'Y':[84,94,89,83,86],'Z':[86,97,96,72,83]});
qgrid.show_grid(df, show_toolbar=True)
```

## Todo after merge
- Fix #300 - a pytest is failing in master currently, which is the same failure noticed in this PR.
- Release version `1.1.3` of the npm package.
- Release version `1.3.1` of the python package. It has been referencing a hardcoded version of the labextension `1.1.1` before, so when the `1.1.2` was released, that made it fail to accept being used together with it. After this PR, we reference `1.1.3` instead.

## Screenshot
![image](https://user-images.githubusercontent.com/3837114/77058075-3a94c400-69d5-11ea-94bc-4ab7f5a4e37d.png)