### PR TITLE
fix: #315 - filters dont work and poorly displayed

### DIFF
--- a/js/src/qgrid.booleanfilter.js
+++ b/js/src/qgrid.booleanfilter.js
@@ -8,7 +8,7 @@ class BooleanFilter extends filter_base.FilterBase {
       <div class='boolean-filter grid-filter qgrid-dropdown-menu'>
         <h3 class='qgrid-popover-title'>
           <div class='dropdown-title'>Filter by ${this.field}</div>
-          <i class='fa fa-times icon-remove close-button'/>
+          <i class='fa fa-times icon-remove close-button'></i>
         </h3>
         <div class='dropdown-body'>
           <form>

--- a/js/src/qgrid.datefilter.js
+++ b/js/src/qgrid.datefilter.js
@@ -8,7 +8,7 @@ class DateFilter extends filter_base.FilterBase {
       <div class='date-range-filter grid-filter qgrid-dropdown-menu'>
         <h3 class='qgrid-popover-title'>
           <div class='dropdown-title'>Filter by ${this.field}</div>
-          <i class='fa fa-times icon-remove close-button'/>
+          <i class='fa fa-times icon-remove close-button'></i>
         </h3>
         <div class='dropdown-body'>
           <input class='datepicker ignore start-date'/>

--- a/js/src/qgrid.sliderfilter.js
+++ b/js/src/qgrid.sliderfilter.js
@@ -7,7 +7,7 @@ class SliderFilter extends filter_base.FilterBase {
       <div class='numerical-filter grid-filter qgrid-dropdown-menu'>
         <h3 class='qgrid-popover-title'>
           <div class='dropdown-title'>Filter by ${this.field}</div>
-          <i class='fa fa-times icon-remove close-button'/>
+          <i class='fa fa-times icon-remove close-button'></i>
         </h3>
         <div class='dropdown-body'>
           <div class='slider-range'/>

--- a/js/src/qgrid.textfilter.js
+++ b/js/src/qgrid.textfilter.js
@@ -9,7 +9,7 @@ class TextFilter extends filter_base.FilterBase {
       <div class='text-filter grid-filter qgrid-dropdown-menu'>
         <h3 class='qgrid-popover-title'>
           <div class='dropdown-title'>Filter by ${this.field}</div>
-          <i class='fa fa-times icon-remove close-button'/>
+          <i class='fa fa-times icon-remove close-button'></i>
         </h3>
         <div class='dropdown-body'>
           <div class='input-area'>


### PR DESCRIPTION
This fixes a severe bug in the filters, caused by a new version of jQuery (qgrid updated it's jQuery version when moved to Jupyter 2). The `<i>` tags must have a closing tag `</i>`, otherwise the dropdown element is rendered inside the `<i>` tag and causes severe bugs (the filter is floating with no background and also the text boxes, sliders and booleans are not clickable. This means the filter is useless).

Before my fix:
![image](https://user-images.githubusercontent.com/45560972/81837998-3b1d8700-954e-11ea-9aca-0d43baac2c55.png)

After my fix:
![image](https://user-images.githubusercontent.com/45560972/81837967-3062f200-954e-11ea-97a8-97210ac6a531.png)

(and also all filters work great now)

Maintainer - can you please release a version after merging this? Thanks.