### PR TITLE
Updating widget model name to qgrid2

### DIFF
--- a/js/src/qgrid.widget.js
+++ b/js/src/qgrid.widget.js
@@ -34,7 +34,7 @@ class QgridModel extends widgets.DOMWidgetModel {
     return _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
       _model_name : 'QgridModel',
       _view_name : 'QgridView',
-      _model_module : 'qgrid',
+      _model_module : 'qgrid2',
       _view_module : 'qgrid',
       _model_module_version : '^1.1.3',
       _view_module_version : '^1.1.3',


### PR DESCRIPTION
Updating the module name to `qgrid2` where I think new releases are being pushed.

This is mostly not an issue if you use from Jupyter because I guess the JS is shipped as part of the package but when you try to load from a browser (nbconvert or voila) it fails to load the latest version from unpkg like this:

<img width="891" alt="Screen Shot 2020-06-08 at 19 40 21" src="https://user-images.githubusercontent.com/1580714/84093839-f952f580-a9c0-11ea-9462-3dcee610c511.png">

Fixes https://github.com/quantopian/qgrid/issues/312