### PR TITLE
Update deprecated decorator usage

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -521,7 +521,7 @@ def stringify(x):
         return str(x)
 
 
-@widgets.register()
+@widgets.register
 class QgridWidget(widgets.DOMWidget):
     """
     The widget class which is instantiated by the ``show_grid`` method. This


### PR DESCRIPTION
This becomes an error in ipywidgets 0.8.0.

See this [commit](https://github.com/jupyter-widgets/ipywidgets/commit/ae040f45fa2c05b173273bcb1392ce267ea3a73e).