### PR TITLE
json conversion from DataFrame to_json method instead of from pandas

### DIFF
--- a/qgrid/grid.py
+++ b/qgrid/grid.py
@@ -957,10 +957,10 @@ class QgridWidget(widgets.DOMWidget):
         else:
             self._row_styles = {}
 
-        df_json = pd_json.to_json(None, df,
-                                  orient='table',
-                                  date_format='iso',
-                                  double_precision=self.precision)
+        df_json = df.to_json(None,
+                             orient='table',
+                             date_format='iso',
+                             double_precision=self.precision)
 
         if update_columns:
             self._interval_columns = []


### PR DESCRIPTION
Allows for developers to override and extend to_json() in their own objects that inherit from pd.DataFrame 

@rgerkin 