### PR TITLE
Copying index.js and extension.js to the static folder in qgrid/qgrid.

### DIFF
--- a/qgrid/static/extension.js
+++ b/qgrid/static/extension.js
@@ -1,0 +1,19 @@
+// This file contains the javascript that is run when the notebook is loaded.
+// It contains some requirejs configuration and the `load_ipython_extension`
+// which is required for any notebook extension.
+
+// Configure requirejs
+if (window.require) {
+    window.require.config({
+        map: {
+            "*" : {
+                "qgrid": "nbextensions/qgrid/index"
+            }
+        }
+    });
+}
+
+// Export the required load_ipython_extension
+module.exports = {
+    load_ipython_extension: function() {}
+};

--- a/qgrid/static/index.js
+++ b/qgrid/static/index.js
@@ -1,0 +1,4 @@
+// Entry point for the notebook bundle containing custom model definitions.
+// Export widget models and views, and the npm package version number.
+module.exports = require('./qgrid.widget.js');
+module.exports.version = require('../package.json').version;


### PR DESCRIPTION
Copying index.js and extension.js to the static folder in qgrid/qgrid so that there are no errors while installing qgrid from source.