### PR TITLE
Limit ipywidgets major version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 notebook>=4.0.0
 pandas>=0.18.0
-ipywidgets>=7.0.0
+ipywidgets==7.*


### PR DESCRIPTION
Limit the ipywidgets dependency versions so that the incompatible 8.x releases won't be installed